### PR TITLE
docs: Add tech stack badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # AI Advantage Sports
 
-AI-powered sports betting analytics platform providing data-driven insights and predictions for smarter wagering decisions.
+[![Live Site](https://img.shields.io/badge/Live-aiadvantagesports.com-00D100?style=for-the-badge&logo=google-chrome&logoColor=white)](https://aiadvantagesports.com)
+[![React](https://img.shields.io/badge/React-20232A?style=flat&logo=react&logoColor=61DAFB)](https://reactjs.org/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-007ACC?style=flat&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-38B2AC?style=flat&logo=tailwind-css&logoColor=white)](https://tailwindcss.com/)
 
-**Live Site:** [aiadvantagesports.com](https://aiadvantagesports.com)
+AI-powered sports betting analytics platform providing data-driven insights and predictions for smarter wagering decisions.
 
 ![AI Advantage Sports Screenshot](https://raw.githubusercontent.com/ianalloway/ai-advantage/main/screenshot.png)
 


### PR DESCRIPTION
## Summary

Adds visual tech stack badges to the README header for better visual appeal and quick identification of the technologies used. The changes include a prominent "Live Site" badge linking to aiadvantagesports.com, plus smaller badges for React, TypeScript, and Tailwind CSS.

## Review & Testing Checklist for Human

- [ ] Preview the README on GitHub to verify all badges render correctly
- [ ] Click each badge link to confirm they navigate to the correct URLs

### Notes

Documentation-only change with no functional impact. The badges use shields.io which is a standard service for GitHub README badges.

---
**Requested by:** Ian Alloway  
**Link to Devin run:** https://app.devin.ai/sessions/79b2218c13784145ac50150fb81d91c1