### PR TITLE
feat: Add Stripe premium tier, email capture, and ETH donation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@radix-ui/react-toggle": "^1.1.0",
         "@radix-ui/react-toggle-group": "^1.1.0",
         "@radix-ui/react-tooltip": "^1.1.4",
+        "@stripe/stripe-js": "^8.7.0",
         "@tanstack/react-query": "^5.56.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -2507,6 +2508,15 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@stripe/stripe-js": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-8.7.0.tgz",
+      "integrity": "sha512-tNUerSstwNC1KuHgX4CASGO0Md3CB26IJzSXmVlSuFvhsBP4ZaEPpY4jxWOn9tfdDscuVT4Kqb8cZ2o9nLCgRQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.16"
+      }
     },
     "node_modules/@swc/core": {
       "version": "1.7.39",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@radix-ui/react-toggle": "^1.1.0",
     "@radix-ui/react-toggle-group": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.4",
+    "@stripe/stripe-js": "^8.7.0",
     "@tanstack/react-query": "^5.56.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -1,0 +1,89 @@
+import { loadStripe } from '@stripe/stripe-js';
+
+// Stripe publishable key - replace with your actual key
+const STRIPE_PUBLISHABLE_KEY = import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY || 'pk_test_placeholder';
+
+// Price ID for the $15/month premium subscription
+export const PREMIUM_PRICE_ID = import.meta.env.VITE_STRIPE_PRICE_ID || 'price_placeholder';
+
+// Initialize Stripe
+let stripePromise: ReturnType<typeof loadStripe> | null = null;
+
+export const getStripe = () => {
+  if (!stripePromise) {
+    stripePromise = loadStripe(STRIPE_PUBLISHABLE_KEY);
+  }
+  return stripePromise;
+};
+
+// Premium features
+export const PREMIUM_FEATURES = [
+  'Live odds from The Odds API',
+  'Advanced backtesting with real historical data',
+  'Unlimited game analysis',
+  'Email alerts for value bets',
+  'Priority support',
+  'API access for custom integrations',
+];
+
+export const FREE_FEATURES = [
+  'Basic ML predictions',
+  'Demo games for NBA, NFL, MLB',
+  'Basic backtesting (simulated)',
+  'Manual game analysis',
+];
+
+// Check if user has premium (stored in localStorage for demo)
+export const isPremiumUser = (): boolean => {
+  if (typeof window === 'undefined') return false;
+  return localStorage.getItem('ai_advantage_premium') === 'true';
+};
+
+export const setPremiumStatus = (isPremium: boolean): void => {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem('ai_advantage_premium', isPremium ? 'true' : 'false');
+};
+
+// Redirect to Stripe Checkout
+export const redirectToCheckout = async (): Promise<void> => {
+  const stripe = await getStripe();
+  if (!stripe) {
+    console.error('Stripe not loaded');
+    return;
+  }
+
+  // In production, you'd create a checkout session on your backend
+  // For now, we'll use Stripe's payment links or show a demo
+  const checkoutUrl = import.meta.env.VITE_STRIPE_CHECKOUT_URL;
+  
+  if (checkoutUrl) {
+    window.location.href = checkoutUrl;
+  } else {
+    // Demo mode - just set premium status
+    console.log('Demo mode: Setting premium status');
+    setPremiumStatus(true);
+    window.location.reload();
+  }
+};
+
+// Email subscription
+export const subscribeEmail = async (email: string): Promise<{ success: boolean; message: string }> => {
+  // In production, you'd send this to your backend/email service
+  // For now, store in localStorage and return success
+  if (!email || !email.includes('@')) {
+    return { success: false, message: 'Please enter a valid email address' };
+  }
+
+  try {
+    // Store email locally (in production, send to backend)
+    const emails = JSON.parse(localStorage.getItem('ai_advantage_emails') || '[]');
+    if (!emails.includes(email)) {
+      emails.push(email);
+      localStorage.setItem('ai_advantage_emails', JSON.stringify(emails));
+    }
+    
+    return { success: true, message: 'Thanks for subscribing! Check your inbox for updates.' };
+  } catch {
+    return { success: false, message: 'Something went wrong. Please try again.' };
+  }
+};


### PR DESCRIPTION
## Summary

Adds monetization features to AI Advantage Sports:

- **Pricing Section**: Free vs Premium ($15/mo) tier comparison with feature lists
- **Email Capture**: Newsletter signup form with localStorage storage (frontend-only for now)
- **ETH Donation**: Copy-to-clipboard donation address in footer and dedicated section
- **Stripe Integration**: Basic setup with `@stripe/stripe-js` - currently in demo mode

The Stripe integration uses environment variables (`VITE_STRIPE_PUBLISHABLE_KEY`, `VITE_STRIPE_CHECKOUT_URL`) and falls back to demo mode when not configured. In demo mode, clicking "Upgrade to Premium" just sets a localStorage flag.

## Review & Testing Checklist for Human

- [ ] **Verify ETH address is correct**: `0xAc7C093B312700614C80Ba3e0509f8dEde03515b` - this is hardcoded and will receive real donations
- [ ] **Understand this is frontend-only**: No backend for payments or email capture yet. Stripe checkout redirects to demo mode, emails store to localStorage only. Real integration requires backend work.
- [ ] **Test the upgrade flow**: Click "Upgrade to Premium" - should reload page and show "Premium Active" button (demo mode behavior)
- [ ] **Test email capture**: Enter email, click Subscribe, verify toast appears

**Test Plan**: Deploy preview, scroll to pricing section, test both the email subscribe and premium upgrade buttons. Verify ETH address copies correctly when clicking the copy button.

### Notes

- `showPricing` state and `Lock` import are unused (minor cleanup opportunity)
- Premium features are not actually gated yet - this PR adds the UI/pricing, not the feature restrictions

**Link to Devin run**: https://app.devin.ai/sessions/79b2218c13784145ac50150fb81d91c1
**Requested by**: Ian Alloway