### PR TITLE
docs: Restore Kelly Criterion, multi-sport, and premium tier features

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ AI-powered sports betting analytics platform providing data-driven insights and 
 - **Real-Time Odds** - Track line movements and find value before the market adjusts
 - **High Accuracy** - Models consistently outperform traditional handicapping methods
 - **Bankroll Protection** - Smart stake sizing recommendations to protect your investment
+- **Kelly Criterion** - Optimal bet sizing based on edge and bankroll management
+- **Multi-Sport Support** - NBA, NFL, and MLB predictions
+- **Premium Tier** - Advanced features with Stripe subscription integration
 
 ## Tech Stack
 


### PR DESCRIPTION
## Summary

Restores three feature descriptions to the README that were previously removed:
- Kelly Criterion bet sizing
- Multi-sport support (NBA, NFL, MLB)
- Premium tier with Stripe integration

## Review & Testing Checklist for Human

- [ ] Verify these features actually exist in the application (Kelly Criterion, multi-sport, premium tier)
- [ ] Confirm the feature descriptions accurately reflect current functionality

### Notes

Low-risk documentation change. No functional code modifications.

**Link to Devin run:** https://app.devin.ai/sessions/79b2218c13784145ac50150fb81d91c1
**Requested by:** Ian Alloway