### PR TITLE
Security: enforce lint in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         run: npx tsc --noEmit
 
       - name: Lint
-        run: npx eslint src --ext .ts,.tsx --max-warnings 0 || true
+        run: npm run lint
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
## Summary
- Removes `|| true` bypass on ESLint in CI
- Uses `npm run lint` as the project-standard lint command

## Test plan
- [ ] CI passes on this PR

Made with [Cursor](https://cursor.com)