### PR TITLE
Prevent replayable crypto tx claims and reject already-claimed transactions

### DIFF
--- a/api/verify-crypto-payment.ts
+++ b/api/verify-crypto-payment.ts
@@ -2,6 +2,7 @@
 // Verifies an Ethereum tx (ETH or USDC/USDT transfer) actually paid the app
 // wallet before any premium access is granted. See issue #36.
 import {
+  CryptoTransactionAlreadyClaimedError,
   createEntitlementSession,
   entitlementSessionCookie,
   getEntitlementStore,
@@ -214,6 +215,14 @@ export default async function handler(req: RequestLike, res: ResponseLike) {
       reason: "Transaction does not pay the app wallet the required amount.",
     });
   } catch (error) {
+    if (error instanceof CryptoTransactionAlreadyClaimedError) {
+      res.status(409).json({
+        verified: false,
+        reason: "This crypto transaction has already been claimed.",
+      });
+      return;
+    }
+
     const message = error instanceof Error ? error.message : "Verification failed.";
     res.status(502).json({ verified: false, reason: message });
   }

--- a/netlify/functions/_lib/entitlements.test.ts
+++ b/netlify/functions/_lib/entitlements.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  CryptoTransactionAlreadyClaimedError,
+  findBestEntitlement,
+  upsertCryptoEntitlement,
+  type EntitlementStore,
+} from "./entitlements";
+
+function memoryStore(): EntitlementStore {
+  const data = new Map<string, unknown>();
+  return {
+    mode: "local",
+    async delete(key: string) {
+      data.delete(key);
+    },
+    async get<T>(key: string) {
+      return (data.get(key) as T | undefined) ?? null;
+    },
+    async set(key: string, value: unknown) {
+      data.set(key, value);
+    },
+  };
+}
+
+describe("upsertCryptoEntitlement", () => {
+  it("rejects replayed crypto transaction hashes without overwriting the original claimant", async () => {
+    const store = memoryStore();
+    const txHash = `0x${"a".repeat(64)}`;
+
+    const original = await upsertCryptoEntitlement(store, {
+      email: "victim@example.com",
+      walletAddress: `0x${"b".repeat(40)}`,
+      txHash,
+      tier: "premium",
+      label: "Crypto Knowledge Vault",
+    });
+
+    await expect(
+      upsertCryptoEntitlement(store, {
+        email: "attacker@example.com",
+        walletAddress: `0x${"b".repeat(40)}`,
+        txHash,
+        tier: "event",
+        label: "Crypto Big Game Pass",
+      }),
+    ).rejects.toBeInstanceOf(CryptoTransactionAlreadyClaimedError);
+
+    const victimEntitlement = await findBestEntitlement(store, { email: "victim@example.com" });
+    const attackerEntitlement = await findBestEntitlement(store, { email: "attacker@example.com" });
+
+    expect(victimEntitlement).toMatchObject({
+      id: original.id,
+      email: "victim@example.com",
+      tier: "premium",
+      cryptoTxHash: txHash,
+    });
+    expect(attackerEntitlement).toBeNull();
+  });
+});

--- a/netlify/functions/_lib/entitlements.ts
+++ b/netlify/functions/_lib/entitlements.ts
@@ -50,6 +50,13 @@ export interface EntitlementStore {
   set: (key: string, value: unknown, options?: { ex?: number }) => Promise<void>;
 }
 
+export class CryptoTransactionAlreadyClaimedError extends Error {
+  constructor(txHash: string) {
+    super(`Crypto transaction has already been claimed: ${normalizeHash(txHash)}`);
+    this.name = "CryptoTransactionAlreadyClaimedError";
+  }
+}
+
 export type EventLike = {
   blobs?: string;
   headers?: Record<string, string | string[] | undefined>;
@@ -538,9 +545,16 @@ export async function upsertCryptoEntitlement(
     label: string;
   },
 ) {
+  const txHash = normalizeHash(input.txHash);
+  const id = `crypto:${txHash}`;
+  const existing = await getRecord(store, id);
+  if (existing) {
+    throw new CryptoTransactionAlreadyClaimedError(txHash);
+  }
+
   const tier = input.tier === "premium" ? "premium" : "event";
   return upsertEntitlement(store, {
-    id: `crypto:${normalizeHash(input.txHash)}`,
+    id,
     tier,
     source: "crypto",
     label: input.label,
@@ -549,6 +563,6 @@ export async function upsertCryptoEntitlement(
     expiresAt: tier === "event" ? eventAccessExpiry() : undefined,
     email: input.email,
     walletAddress: input.walletAddress,
-    cryptoTxHash: input.txHash,
+    cryptoTxHash: txHash,
   });
 }


### PR DESCRIPTION
### Motivation
- Close a high-severity vulnerability where an attacker could replay a public Ethereum transaction hash and mint an entitlement cookie or overwrite an existing claimant.
- Ensure crypto entitlements are bound to the first verified claimant and prevent unauthorized re-claims.

### Description
- Add `CryptoTransactionAlreadyClaimedError` and check for an existing `crypto:<normalizedHash>` record in `upsertCryptoEntitlement` to reject replay attempts instead of merging/overwriting (updated `netlify/functions/_lib/entitlements.ts`).
- Normalize the `txHash` early and preserve the deterministic entitlement id `crypto:<normalizedHash>` while keeping the original claimant’s metadata intact (updated `upsertCryptoEntitlement`).
- Catch the new error in the verification API and return HTTP `409` with a clear reason instead of creating a new entitlement session and `Set-Cookie` (updated `api/verify-crypto-payment.ts`).
- Add a regression test `netlify/functions/_lib/entitlements.test.ts` that asserts replayed transaction hashes are rejected and do not grant access to a different email.

### Testing
- Ran `npm test` and all tests passed (Test Files: 3 passed, Tests: 21 passed).
- Ran `npm run lint` which completed with warnings but no errors.
- Ran `npm run build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5003b619b0832e89b1c09da96a76cf)