### PR TITLE
fix: prevent crypto payment transaction replay

### DIFF
--- a/api/verify-crypto-payment.ts
+++ b/api/verify-crypto-payment.ts
@@ -5,7 +5,7 @@ import {
   createEntitlementSession,
   entitlementSessionCookie,
   getEntitlementStore,
-  upsertCryptoEntitlement,
+  claimCryptoEntitlement,
   type AccessTier,
 } from "../netlify/functions/_lib/entitlements";
 
@@ -166,7 +166,7 @@ export default async function handler(req: RequestLike, res: ResponseLike) {
           res.status(503).json({ verified: false, reason: "Entitlement backend is not configured." });
           return;
         }
-        const entitlement = await upsertCryptoEntitlement(store, {
+        const entitlement = await claimCryptoEntitlement(store, {
           email,
           walletAddress,
           txHash,
@@ -196,7 +196,7 @@ export default async function handler(req: RequestLike, res: ResponseLike) {
         res.status(503).json({ verified: false, reason: "Entitlement backend is not configured." });
         return;
       }
-      const entitlement = await upsertCryptoEntitlement(store, {
+      const entitlement = await claimCryptoEntitlement(store, {
         email,
         walletAddress,
         txHash,
@@ -215,6 +215,10 @@ export default async function handler(req: RequestLike, res: ResponseLike) {
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : "Verification failed.";
+    if (message === "CRYPTO_TRANSACTION_ALREADY_CLAIMED") {
+      res.status(409).json({ verified: false, reason: "This transaction hash has already been claimed." });
+      return;
+    }
     res.status(502).json({ verified: false, reason: message });
   }
 }

--- a/netlify/functions/_lib/entitlements.ts
+++ b/netlify/functions/_lib/entitlements.ts
@@ -528,7 +528,7 @@ export async function upsertStripeSubscriptionEntitlement(
   });
 }
 
-export async function upsertCryptoEntitlement(
+export async function claimCryptoEntitlement(
   store: EntitlementStore,
   input: {
     email: string;
@@ -539,16 +539,36 @@ export async function upsertCryptoEntitlement(
   },
 ) {
   const tier = input.tier === "premium" ? "premium" : "event";
+  const txHash = normalizeHash(input.txHash);
+  const email = normalizeEmail(input.email);
+  const walletAddress = normalizeWallet(input.walletAddress);
+  const id = `crypto:${txHash}`;
+  const existing = await getRecord(store, id);
+
+  if (existing) {
+    const sameClaimant =
+      existing.email === email &&
+      existing.walletAddress === walletAddress &&
+      existing.tier === tier &&
+      existing.cryptoTxHash === txHash;
+
+    if (!sameClaimant) {
+      throw new Error("CRYPTO_TRANSACTION_ALREADY_CLAIMED");
+    }
+
+    return existing;
+  }
+
   return upsertEntitlement(store, {
-    id: `crypto:${normalizeHash(input.txHash)}`,
+    id,
     tier,
     source: "crypto",
     label: input.label,
     status: "active",
     activatedAt: new Date().toISOString(),
     expiresAt: tier === "event" ? eventAccessExpiry() : undefined,
-    email: input.email,
-    walletAddress: input.walletAddress,
-    cryptoTxHash: input.txHash,
+    email,
+    walletAddress,
+    cryptoTxHash: txHash,
   });
 }


### PR DESCRIPTION
### Motivation

- The on-chain verifier previously accepted public `txHash` and `walletAddress` values and upserted entitlements without binding or one-time consumption, allowing replay attacks that grant paid access to arbitrary emails/devices.

### Description

- Add `claimCryptoEntitlement` (replaces the prior upsert behavior) to normalize inputs, check for an existing `crypto:<txHash>` record, and reject reuse if the existing claim does not match the same email, wallet, and tier.
- Preserve first-time entitlement creation by creating a transaction-scoped record with normalized `cryptoTxHash`, `walletAddress`, and `email` when no prior claim exists.
- Update the server verifier in `api/verify-crypto-payment.ts` to call `claimCryptoEntitlement` for both ETH and stablecoin paths and to set the entitlement session cookie before returning success.
- Return a clear `409` response when a transaction hash has already been claimed by a different claimant, and propagate other verification errors with `502` as before.

### Testing

- Ran `npm run lint`; lint completed with warnings only and no errors. 
- Ran `npm run build`; the production build and prerender succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a50080f8e48832e954968e1a1890e56)