### PR TITLE
Fix browser auth storage and vulnerable dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -784,9 +784,9 @@
       }
     },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.7.1.tgz",
-      "integrity": "sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.10.0.tgz",
+      "integrity": "sha512-bvyMcgLEkozzSzpEEEo1OMoeQ97bxj6Qs2uN3mPrSdDvObMI1myffD/BPqcLlzZO9//d1SqQA/WPw7Cz2AiqhA==",
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -796,9 +796,9 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
-      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -828,12 +828,29 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
-      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.10.0.tgz",
+      "integrity": "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.10.0.tgz",
+      "integrity": "sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -844,13 +861,14 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
-      "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.10.0.tgz",
+      "integrity": "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -861,14 +879,14 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.7.1.tgz",
-      "integrity": "sha512-pCpQxU68lV+I9s9svqMyVu5iHdDDUnqUpSxqwyCU8A9ejEsSnMPCbearwsUO4yk08ZJzAIUCFuReMdVQvHrdvg==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.10.0.tgz",
+      "integrity": "sha512-GZK/G6oZyBLGlH1pUgeDch7D91KoHd2uotUGIkWCPi9GI5T9X0p4L7nNAMDR1BQjkRYoDqo+ddfVx9t5Uhys+Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "2.7.1",
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/sdk-trace-base": "2.7.1"
+        "@opentelemetry/context-async-hooks": "2.10.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/sdk-trace-base": "2.10.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -3092,16 +3110,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {

--- a/package.json
+++ b/package.json
@@ -55,5 +55,12 @@
     "typescript-eslint": "^8.64.0",
     "vite": "^8.1.4",
     "vitest": "^4.1.10"
+  },
+  "overrides": {
+    "@opentelemetry/core": "2.10.0",
+    "@opentelemetry/resources": "2.10.0",
+    "@opentelemetry/sdk-trace-base": "2.10.0",
+    "@opentelemetry/sdk-trace-node": "2.10.0",
+    "brace-expansion": "5.0.8"
   }
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -17,10 +17,14 @@ interface AuthResponse {
   user?: SiteUser | null;
 }
 
-const ACCOUNT_STORAGE_KEY = "ai_advantage_site_accounts_v1";
-const SESSION_STORAGE_KEY = "ai_advantage_site_session_v1";
-const CACHED_USER_STORAGE_KEY = "ai_advantage_cached_user_v2";
 const AUTH_CHANGE_EVENT = "ai-advantage-auth-changed";
+
+// Authentication state is intentionally memory-only. The production session
+// is held by the server in an HttpOnly cookie; the development fallback must
+// not persist identities, password hashes, or session identifiers in browser
+// storage.
+let cachedUser: SiteUser | null = null;
+let legacyAccounts: StoredSiteUser[] = [];
 
 function emitAuthChange(): void {
   if (typeof window === "undefined") return;
@@ -41,53 +45,24 @@ function sanitizeUser(user: StoredSiteUser): SiteUser {
 }
 
 function setCachedUser(user: SiteUser | null): void {
-  if (typeof window === "undefined") return;
-
-  if (user) {
-    localStorage.setItem(CACHED_USER_STORAGE_KEY, JSON.stringify(user));
-  } else {
-    localStorage.removeItem(CACHED_USER_STORAGE_KEY);
-  }
+  cachedUser = user;
 }
 
 function getCachedUser(): SiteUser | null {
-  if (typeof window === "undefined") return null;
-
-  const stored = localStorage.getItem(CACHED_USER_STORAGE_KEY);
-  if (!stored) return null;
-
-  try {
-    const parsed = JSON.parse(stored) as SiteUser;
-    return parsed?.id && parsed?.email ? parsed : null;
-  } catch {
-    localStorage.removeItem(CACHED_USER_STORAGE_KEY);
-    return null;
-  }
+  return cachedUser;
 }
 
 function loadLegacyAccounts(): StoredSiteUser[] {
-  if (typeof window === "undefined") return [];
-
-  const stored = localStorage.getItem(ACCOUNT_STORAGE_KEY);
-  if (!stored) return [];
-
-  try {
-    const parsed = JSON.parse(stored) as StoredSiteUser[];
-    return Array.isArray(parsed) ? parsed : [];
-  } catch {
-    localStorage.removeItem(ACCOUNT_STORAGE_KEY);
-    return [];
-  }
+  return [...legacyAccounts];
 }
 
 function saveLegacyAccounts(accounts: StoredSiteUser[]): void {
-  if (typeof window === "undefined") return;
-  localStorage.setItem(ACCOUNT_STORAGE_KEY, JSON.stringify(accounts));
+  legacyAccounts = [...accounts];
 }
 
 async function legacyHashPassword(password: string): Promise<string> {
   if (typeof window === "undefined" || !window.crypto?.subtle) {
-    return password;
+    throw new Error("Secure browser cryptography is unavailable.");
   }
 
   const bytes = new TextEncoder().encode(password);
@@ -170,7 +145,6 @@ async function signUpLegacySiteUser(input: {
 
   accounts.push(nextAccount);
   saveLegacyAccounts(accounts);
-  localStorage.setItem(SESSION_STORAGE_KEY, nextAccount.id);
   const user = sanitizeUser(nextAccount);
   setCachedUser(user);
   emitAuthChange();
@@ -203,7 +177,6 @@ async function signInLegacySiteUser(input: {
     return { success: false, message: "That password does not match this account." };
   }
 
-  localStorage.setItem(SESSION_STORAGE_KEY, account.id);
   const user = sanitizeUser(account);
   setCachedUser(user);
   emitAuthChange();
@@ -229,7 +202,6 @@ export async function syncSiteUserSession(): Promise<SiteUser | null> {
     const payload = await requestAuth("me", { method: "GET" });
     const user = payload.user ?? null;
     setCachedUser(user);
-    localStorage.removeItem(SESSION_STORAGE_KEY);
     emitAuthChange();
     return user;
   } catch (error) {
@@ -265,7 +237,6 @@ export async function signUpSiteUser(input: {
     }
 
     setCachedUser(payload.user);
-    localStorage.removeItem(SESSION_STORAGE_KEY);
     emitAuthChange();
     return {
       success: true,
@@ -305,7 +276,6 @@ export async function signInSiteUser(input: {
     }
 
     setCachedUser(payload.user);
-    localStorage.removeItem(SESSION_STORAGE_KEY);
     emitAuthChange();
     return { success: true, message: payload.message || "Logged in successfully.", user: payload.user };
   } catch (error) {
@@ -325,7 +295,6 @@ export function signOutSiteUser(): void {
 
   void requestAuth("logout", { method: "POST", body: "{}" }).catch(() => undefined);
   setCachedUser(null);
-  localStorage.removeItem(SESSION_STORAGE_KEY);
   // Paid access is a separate cookie/local cache — clear it on account logout so
   // shared devices don't keep the premium board unlocked.
   void import("@/lib/stripe")

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
           { "path": "./tsconfig.node.json" }
     ],
     "compilerOptions": {
-          "ignoreDeprecations": "6.0",
+          "ignoreDeprecations": "5.0",
           "baseUrl": ".",
           "paths": {
                   "@/*": ["./src/*"]


### PR DESCRIPTION
## Summary
- keep browser authentication state in memory instead of persistent localStorage
- continue using the server HttpOnly cookie as the production session source of truth
- update vulnerable brace-expansion and OpenTelemetry transitive dependencies to patched versions

## Validation
- npm run lint (warnings only, no errors)
- npm test (36 passed)
- npm run build