### PR TITLE
feat: Portfolio Risk View — correlated slate exposure and stake haircut

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ It's the product layer of a larger sports-analytics stack — the modeling lives
 | Game analyzer | Enter a matchup, get an analysis and a recommendation |
 | Live odds | Track lines and movement across the slate |
 | Kelly sizing | Translate edge + bankroll into a stake |
+| Portfolio risk | Correlated exposure by team, game, sport, and narrative, with a stake haircut |
 | Multi-sport | NBA, NFL, MLB workflows |
 | Premium | Stripe subscription + one-time checkout |
 | Newsletter | Notion-backed capture wired into Substack |

--- a/docs/advantage_operating_system.md
+++ b/docs/advantage_operating_system.md
@@ -149,7 +149,7 @@ It should position as:
    - Show bets by urgency
    - Example: `hit now`, `watch`, `pass if moves 5 cents more`
 
-4. `Portfolio Risk View`
+4. `Portfolio Risk View` — shipped, see `docs/portfolio_risk.md`
    - Show correlated exposure across teams, games, and slates
    - Stop over-betting one narrative in different wrappers
 

--- a/docs/portfolio_risk.md
+++ b/docs/portfolio_risk.md
@@ -1,0 +1,96 @@
+# Portfolio Risk View
+
+A slate of individually-sized Kelly bets is not a portfolio. Three bets on the same game, or six bets on one night's favorites, are closer to one large position than to six small ones. Per-bet Kelly sizing is blind to this: it prices each bet as if it were the only bet on the board.
+
+The Portfolio Risk View reads the whole filtered desk at once, groups it into exposure buckets, prices the correlation between positions, and returns a stake haircut that brings every bucket back inside its limit.
+
+Implementation: `src/lib/portfolioRisk.ts` (pure, tested) and `src/components/PortfolioRiskView.tsx` (presentation). The panel renders in the `/daily-picks` sidebar.
+
+## Positions
+
+The page maps each priced value bet on the desk to a `RiskPosition`: side, opponent, sport, game id, suggested stake, model probability, and the American price.
+
+Risk is measured over the bets the user can actually place — the open board alone until premium unlocks the rest of the slate. A free user's exposure number describes their real actionable slate, not a slate they cannot see.
+
+## Exposure buckets
+
+Every position is added to four buckets:
+
+- `team` — the recommended side
+- `game` — the event, so two angles on one game aggregate
+- `sport` — league-level concentration
+- `narrative` — favorites, underdogs, or draw prices
+
+Each bucket carries its stake, its share of bankroll, and its limit. Limits come from the user's risk profile:
+
+| Profile | Team | Game | Sport | Total | Narrative share |
+|---------|------|------|-------|-------|-----------------|
+| conservative | 2% | 3% | 7% | 10% | 55% |
+| balanced | 3% | 4% | 10% | 15% | 65% |
+| aggressive | 5% | 6% | 15% | 25% | 75% |
+
+Team, game, sport, and total limits are percentages of bankroll. The narrative limit is a share of total staked, since "too many favorites" is a claim about the shape of the slate rather than its size.
+
+A narrative bucket holding fewer than three positions is not treated as a theme — it is just the bets themselves — so it is neither flagged nor charted.
+
+## Correlation
+
+Position sigma is the standard deviation of a single bet's P&L:
+
+```text
+sigma(i) = stake * decimalOdds * sqrt(p * (1 - p))
+```
+
+Portfolio sigma applies a correlation matrix:
+
+```text
+correlatedSigma = sqrt( sum(i) sum(j) rho(i,j) * sigma(i) * sigma(j) )
+correlationMultiple = correlatedSigma / independentSigma
+```
+
+`rho` is a coarse assumption table, not a fitted covariance matrix:
+
+| Relationship | rho |
+|--------------|-----|
+| Same side, same game | 1.0 |
+| Opposite sides, same game | -1.0 |
+| Same game, other bet | 0.6 |
+| Same team, different games | 0.5 |
+| Same sport, same slate | 0.15 |
+| Different sport | 0.05 |
+
+The point is to stop a desk from treating six bets on one slate as six independent coin flips, not to claim a precise correlation. Because the table is a heuristic it is not guaranteed positive semi-definite — a hedged book can drive the variance sum below zero, so it is floored at zero rather than reporting an imaginary sigma.
+
+`correlationMultiple` above `1.0` means correlation is inflating risk beyond the independent case. It is surfaced directly on the card because it is the number per-bet Kelly cannot see.
+
+## Diversification score
+
+`100 * (1 - HHI)` over game-level stake weights, where `HHI` is the Herfindahl index. Game-level, not position-level: two bets inside one game are one bet for diversification purposes.
+
+One position scores 0. Two equal games score 50. Five equal games score 80.
+
+## The haircut
+
+Two reductions, kept separate so each stays explainable:
+
+1. `limitScale` — per position, the tightest ratio across every over-limit bucket it belongs to, plus the total-exposure ceiling. Because every member of an over-limit bucket is scaled by at least `limit / bucketStake`, the bucket lands inside its limit after scaling.
+2. `correlationScale` — a blanket multiplier applied only once `correlationMultiple` passes a tolerance of `1.25`, scaling back toward that tolerance rather than toward zero correlation. Any multi-bet slate carries some shared risk; a haircut that fired at the first sign of correlation would just shrink every plan.
+
+```text
+suggestedStake(i) = stake(i) * limitScale(i)
+suggestedTotalStake = sum(suggestedStake) * correlationScale
+```
+
+## Product principles
+
+- Show the exposure of bets the user can actually place, never a slate they cannot see.
+- Never display a limit that is not being enforced.
+- State the correlation assumptions on the card — they are assumptions, and the user is entitled to discount them.
+- An empty desk shows an empty panel rather than invented exposure.
+
+## Next implementation steps
+
+1. Persist realized correlation between settled positions and replace the assumption table where the data supports it.
+2. Extend beyond moneyline once sides, totals, and props are on the board — a total and a side in one game correlate differently than two sides.
+3. Carry open positions from prior slates into the exposure math, not just today's board.
+4. Feed the haircut back into the displayed Kelly stake on each pick card, behind an explicit toggle.

--- a/src/components/PortfolioRiskView.tsx
+++ b/src/components/PortfolioRiskView.tsx
@@ -1,0 +1,290 @@
+import { useMemo, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  AlertTriangle,
+  ChevronDown,
+  ChevronUp,
+  Layers,
+  Lock,
+  Scissors,
+  Shield,
+  ShieldCheck,
+} from "lucide-react";
+import {
+  analyzePortfolioRisk,
+  type ExposureDimension,
+  type PortfolioRiskReport,
+  type RiskPosition,
+} from "@/lib/portfolioRisk";
+import type { RiskProfile } from "@/lib/profile";
+
+const DIMENSION_LABEL: Record<ExposureDimension, string> = {
+  team: "Team",
+  game: "Game",
+  sport: "Sport",
+  narrative: "Narrative",
+};
+
+function money(value: number) {
+  return `$${Math.round(value).toLocaleString()}`;
+}
+
+function toneForExposure(report: PortfolioRiskReport) {
+  if (report.warnings.some((warning) => warning.severity === "high")) {
+    return { text: "text-red-300", ring: "border-red-400/30 bg-red-400/10", label: "Concentrated" };
+  }
+  if (report.warnings.length > 0) {
+    return { text: "text-amber-300", ring: "border-amber-400/30 bg-amber-400/10", label: "Watch" };
+  }
+  return { text: "text-emerald-300", ring: "border-emerald-400/30 bg-emerald-400/10", label: "Balanced" };
+}
+
+function MetricTile({ label, value, sub, tone }: { label: string; value: string; sub: string; tone: string }) {
+  return (
+    <div className="rounded-2xl border border-white/5 bg-black/20 p-3">
+      <p className="text-[10px] uppercase tracking-wider text-zinc-500">{label}</p>
+      <p className={`mt-1 font-mono text-lg font-black ${tone}`}>{value}</p>
+      <p className="mt-0.5 text-[11px] leading-tight text-zinc-500">{sub}</p>
+    </div>
+  );
+}
+
+function ClusterBar({
+  label,
+  dimension,
+  positions,
+  bankrollPct,
+  limitPct,
+  overLimit,
+}: {
+  label: string;
+  dimension: ExposureDimension;
+  positions: number;
+  bankrollPct: number;
+  limitPct: number;
+  overLimit: boolean;
+}) {
+  const fill = limitPct > 0 ? Math.min((bankrollPct / limitPct) * 100, 100) : 0;
+
+  return (
+    <div>
+      <div className="flex items-center justify-between gap-2 text-xs">
+        <span className="flex min-w-0 items-center gap-1.5">
+          <span className="shrink-0 rounded border border-white/10 px-1 py-0.5 text-[9px] uppercase tracking-wider text-zinc-500">
+            {DIMENSION_LABEL[dimension]}
+          </span>
+          <span className="truncate text-zinc-300">{label}</span>
+          {positions > 1 ? <span className="shrink-0 text-[10px] text-zinc-600">×{positions}</span> : null}
+        </span>
+        <span className={`shrink-0 font-mono ${overLimit ? "text-red-300" : "text-zinc-400"}`}>
+          {bankrollPct.toFixed(1)}% / {limitPct.toFixed(1)}%
+        </span>
+      </div>
+      <div className="mt-1.5 h-1.5 overflow-hidden rounded-full bg-white/[0.06]">
+        <div
+          className={`h-full rounded-full ${overLimit ? "bg-red-400" : "bg-cyan-300/70"}`}
+          style={{ width: `${fill}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default function PortfolioRiskView({
+  positions,
+  bankroll,
+  riskProfile = "balanced",
+  locked = false,
+  onUnlock,
+}: {
+  positions: RiskPosition[];
+  bankroll: number;
+  riskProfile?: RiskProfile;
+  locked?: boolean;
+  onUnlock?: () => void;
+}) {
+  const [isOpen, setIsOpen] = useState(true);
+
+  const report = useMemo(
+    () => analyzePortfolioRisk(positions, bankroll, riskProfile),
+    [positions, bankroll, riskProfile],
+  );
+
+  const tone = toneForExposure(report);
+  const visibleClusters = useMemo(
+    () =>
+      report.clusters
+        .filter((cluster) => {
+          // Below three positions a narrative bucket is just the bets themselves, and
+          // its limit is not enforced — showing the bar would imply a cap that is not real.
+          if (cluster.dimension === "narrative") return cluster.positions >= 3;
+          return cluster.positions > 1 || cluster.overLimit;
+        })
+        .slice(0, 6),
+    [report.clusters],
+  );
+
+  return (
+    <div className="rounded-[24px] border border-white/10 bg-white/[0.03] p-5">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2">
+          {report.warnings.length > 0 ? (
+            <Shield className={`h-4 w-4 ${tone.text}`} />
+          ) : (
+            <ShieldCheck className={`h-4 w-4 ${tone.text}`} />
+          )}
+          <div>
+            <h3 className="text-sm font-bold text-white">Portfolio risk</h3>
+            <p className="text-[11px] text-zinc-500">Correlated exposure across the filtered desk</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <Badge variant="outline" className={`text-[10px] ${tone.ring} ${tone.text}`}>
+            {tone.label}
+          </Badge>
+          <button
+            type="button"
+            aria-label={isOpen ? "Collapse portfolio risk" : "Expand portfolio risk"}
+            className="text-zinc-500 transition hover:text-white"
+            onClick={() => setIsOpen((open) => !open)}
+          >
+            {isOpen ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+          </button>
+        </div>
+      </div>
+
+      {isOpen ? (
+        report.positions === 0 ? (
+          <p className="mt-4 text-xs leading-5 text-zinc-500">
+            No sized positions on the desk right now. Lower the execution-edge filter or wait for the next slate — this
+            panel stays empty rather than inventing exposure.
+          </p>
+        ) : (
+          <>
+            <div className="mt-4 grid grid-cols-2 gap-2">
+              <MetricTile
+                label="Slate exposure"
+                value={`${report.exposurePct.toFixed(1)}%`}
+                sub={`${money(report.totalStake)} across ${report.positions} ${report.positions === 1 ? "position" : "positions"}`}
+                tone={tone.text}
+              />
+              <MetricTile
+                label="1σ swing"
+                value={`±${report.oneSigmaSwingPct.toFixed(1)}%`}
+                sub={`±${money(report.correlatedSigma)} on a typical night`}
+                tone="text-white"
+              />
+              <MetricTile
+                label="Correlation"
+                value={`${report.correlationMultiple.toFixed(2)}×`}
+                sub={
+                  report.correlationMultiple > 1.25
+                    ? "These bets lose together"
+                    : "Close to independent risk"
+                }
+                tone={report.correlationMultiple > 1.25 ? "text-red-300" : "text-emerald-300"}
+              />
+              <MetricTile
+                label="Diversification"
+                value={`${report.diversificationScore}`}
+                sub={`Expected ${report.expectedValue >= 0 ? "+" : "−"}${money(Math.abs(report.expectedValue))} on the slate`}
+                tone={report.diversificationScore >= 60 ? "text-emerald-300" : "text-amber-300"}
+              />
+            </div>
+
+            {locked ? (
+              <div className="mt-4 rounded-2xl border border-yellow-400/20 bg-yellow-400/[0.06] p-4">
+                <div className="flex items-center gap-2 text-xs font-semibold text-yellow-200">
+                  <Lock className="h-3.5 w-3.5" />
+                  Exposure breakdown is premium
+                </div>
+                <p className="mt-2 text-[11px] leading-5 text-zinc-400">
+                  The headline numbers stay open. Unlock to see which team, game, and narrative buckets are over their
+                  limits — and the stake haircut that pulls them back.
+                </p>
+                {onUnlock ? (
+                  <Button
+                    size="sm"
+                    className="mt-3 bg-cyan-300 font-semibold text-slate-950 hover:bg-cyan-200"
+                    onClick={onUnlock}
+                  >
+                    Unlock risk view
+                  </Button>
+                ) : null}
+              </div>
+            ) : (
+              <>
+                {report.warnings.length > 0 ? (
+                  <ul className="mt-4 space-y-2">
+                    {report.warnings.slice(0, 4).map((warning) => (
+                      <li
+                        key={warning.code}
+                        className={`flex gap-2 rounded-xl border p-2.5 text-[11px] leading-5 ${
+                          warning.severity === "high"
+                            ? "border-red-400/20 bg-red-400/[0.07] text-red-100"
+                            : "border-amber-400/20 bg-amber-400/[0.07] text-amber-100"
+                        }`}
+                      >
+                        <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                        <span>{warning.message}</span>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="mt-4 rounded-xl border border-emerald-400/20 bg-emerald-400/[0.07] p-2.5 text-[11px] leading-5 text-emerald-100">
+                    Every team, game, and sport bucket is inside its {riskProfile} limit. No trim needed.
+                  </p>
+                )}
+
+                {visibleClusters.length > 0 ? (
+                  <div className="mt-4">
+                    <div className="flex items-center gap-1.5 text-[10px] uppercase tracking-wider text-zinc-500">
+                      <Layers className="h-3 w-3" />
+                      Exposure buckets
+                    </div>
+                    <div className="mt-3 space-y-3">
+                      {visibleClusters.map((cluster) => (
+                        <ClusterBar
+                          key={cluster.key}
+                          label={cluster.label}
+                          dimension={cluster.dimension}
+                          positions={cluster.positions}
+                          bankrollPct={cluster.bankrollPct}
+                          limitPct={cluster.limitPct}
+                          overLimit={cluster.overLimit}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                ) : null}
+
+                {report.haircutPct > 0 ? (
+                  <div className="mt-4 rounded-2xl border border-cyan-300/20 bg-cyan-300/[0.06] p-3">
+                    <div className="flex items-center gap-1.5 text-[10px] uppercase tracking-wider text-cyan-200">
+                      <Scissors className="h-3 w-3" />
+                      De-correlated plan
+                    </div>
+                    <p className="mt-2 text-xs leading-5 text-zinc-300">
+                      Trim the slate {report.haircutPct.toFixed(0)}% — {money(report.totalStake)} down to{" "}
+                      <span className="font-mono font-semibold text-cyan-200">{money(report.suggestedTotalStake)}</span>{" "}
+                      — and every bucket lands inside its limit.
+                      {report.correlationScale < 1
+                        ? ` Includes a ${((1 - report.correlationScale) * 100).toFixed(0)}% correlation haircut on top of the bucket caps.`
+                        : ""}
+                    </p>
+                  </div>
+                ) : null}
+              </>
+            )}
+
+            <p className="mt-4 border-t border-white/5 pt-3 text-[10px] leading-4 text-zinc-600">
+              Limits follow your {riskProfile} risk profile against a {money(report.bankroll)} bankroll. Correlations are
+              coarse assumptions — same game, same team, same league — not a fitted covariance matrix.
+            </p>
+          </>
+        )
+      ) : null}
+    </div>
+  );
+}

--- a/src/lib/portfolioRisk.test.ts
+++ b/src/lib/portfolioRisk.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+import { analyzePortfolioRisk, positionCorrelation, type RiskPosition } from "./portfolioRisk";
+
+function position(overrides: Partial<RiskPosition> & Pick<RiskPosition, "id">): RiskPosition {
+  return {
+    gameId: `game-${overrides.id}`,
+    sport: "nba",
+    sportLabel: "NBA",
+    team: `Team ${overrides.id}`,
+    opponent: `Opp ${overrides.id}`,
+    side: "Home",
+    stake: 20,
+    modelProb: 0.56,
+    americanOdds: -110,
+    ...overrides,
+  };
+}
+
+describe("positionCorrelation", () => {
+  it("treats the same side of the same game as one position", () => {
+    const a = position({ id: "a", gameId: "g1", team: "Lakers" });
+    const b = position({ id: "b", gameId: "g1", team: "Lakers" });
+    expect(positionCorrelation(a, b)).toBe(1);
+  });
+
+  it("treats opposite sides of one game as a hedge", () => {
+    const a = position({ id: "a", gameId: "g1", team: "Lakers", side: "Home" });
+    const b = position({ id: "b", gameId: "g1", team: "Celtics", side: "Away" });
+    expect(positionCorrelation(a, b)).toBe(-1);
+  });
+
+  it("ranks same-sport above cross-sport correlation", () => {
+    const a = position({ id: "a", gameId: "g1", sport: "nba" });
+    const b = position({ id: "b", gameId: "g2", sport: "nba" });
+    const c = position({ id: "c", gameId: "g3", sport: "nfl" });
+    expect(positionCorrelation(a, b)).toBeGreaterThan(positionCorrelation(a, c));
+  });
+});
+
+describe("analyzePortfolioRisk", () => {
+  it("returns a zeroed report for an empty slate", () => {
+    const report = analyzePortfolioRisk([], 1000);
+    expect(report.positions).toBe(0);
+    expect(report.totalStake).toBe(0);
+    expect(report.warnings).toEqual([]);
+    expect(report.correlationMultiple).toBe(1);
+  });
+
+  it("ignores positions with no stake", () => {
+    const report = analyzePortfolioRisk(
+      [position({ id: "a", stake: 25 }), position({ id: "b", stake: 0 })],
+      1000,
+    );
+    expect(report.positions).toBe(1);
+    expect(report.totalStake).toBe(25);
+  });
+
+  it("inflates risk when every position sits in one game", () => {
+    const stacked = analyzePortfolioRisk(
+      [
+        position({ id: "a", gameId: "g1", team: "Lakers" }),
+        position({ id: "b", gameId: "g1", team: "Lakers" }),
+        position({ id: "c", gameId: "g1", team: "Lakers" }),
+      ],
+      1000,
+    );
+    const spread = analyzePortfolioRisk(
+      [
+        position({ id: "a", gameId: "g1", sport: "nba", team: "Lakers" }),
+        position({ id: "b", gameId: "g2", sport: "nfl", team: "Chiefs" }),
+        position({ id: "c", gameId: "g3", sport: "mlb", team: "Dodgers" }),
+      ],
+      1000,
+    );
+
+    expect(stacked.correlationMultiple).toBeGreaterThan(spread.correlationMultiple);
+    expect(stacked.correlatedSigma).toBeGreaterThan(stacked.independentSigma);
+    expect(spread.diversificationScore).toBeGreaterThan(stacked.diversificationScore);
+  });
+
+  it("never reports a negative sigma for a fully hedged book", () => {
+    const report = analyzePortfolioRisk(
+      [
+        position({ id: "a", gameId: "g1", team: "Lakers", side: "Home" }),
+        position({ id: "b", gameId: "g1", team: "Celtics", side: "Away" }),
+      ],
+      1000,
+    );
+    expect(report.correlatedSigma).toBeGreaterThanOrEqual(0);
+    expect(Number.isNaN(report.correlatedSigma)).toBe(false);
+    expect(report.correlationMultiple).toBeLessThan(1);
+  });
+
+  it("flags an over-limit team cluster and trims it back under the limit", () => {
+    const report = analyzePortfolioRisk(
+      [
+        position({ id: "a", gameId: "g1", team: "Lakers", stake: 40 }),
+        position({ id: "b", gameId: "g2", team: "Lakers", stake: 40 }),
+      ],
+      1000,
+      "balanced",
+    );
+
+    const teamCluster = report.clusters.find((cluster) => cluster.key === "team:Lakers");
+    expect(teamCluster?.bankrollPct).toBe(8);
+    expect(teamCluster?.overLimit).toBe(true);
+    expect(report.warnings.some((warning) => warning.code === "team:Lakers")).toBe(true);
+
+    const trimmed = report.scaledPositions.reduce((sum, entry) => sum + entry.suggestedStake, 0);
+    // 3% team limit on a 1000 bankroll.
+    expect(trimmed).toBeLessThanOrEqual(30 + 1e-6);
+    expect(report.haircutPct).toBeGreaterThan(0);
+  });
+
+  it("leaves a compliant slate untouched", () => {
+    const report = analyzePortfolioRisk(
+      [
+        position({ id: "a", gameId: "g1", sport: "nba", team: "Lakers", stake: 10, americanOdds: -110 }),
+        position({ id: "b", gameId: "g2", sport: "nfl", team: "Chiefs", stake: 10, americanOdds: 120 }),
+      ],
+      1000,
+      "balanced",
+    );
+
+    expect(report.warnings).toEqual([]);
+    expect(report.scaledPositions.every((entry) => entry.limitScale === 1)).toBe(true);
+    expect(report.suggestedTotalStake).toBe(report.totalStake);
+    expect(report.haircutPct).toBe(0);
+  });
+
+  it("tightens limits for a conservative profile", () => {
+    const positions = [
+      position({ id: "a", gameId: "g1", sport: "nba", team: "Lakers", stake: 25 }),
+      position({ id: "b", gameId: "g2", sport: "nba", team: "Celtics", stake: 25 }),
+      position({ id: "c", gameId: "g3", sport: "nba", team: "Heat", stake: 25 }),
+    ];
+
+    const conservative = analyzePortfolioRisk(positions, 1000, "conservative");
+    const aggressive = analyzePortfolioRisk(positions, 1000, "aggressive");
+
+    expect(conservative.warnings.length).toBeGreaterThan(aggressive.warnings.length);
+    expect(conservative.suggestedTotalStake).toBeLessThan(aggressive.suggestedTotalStake);
+  });
+
+  it("does not call a single position a narrative", () => {
+    const report = analyzePortfolioRisk([position({ id: "a", stake: 200, americanOdds: -150 })], 1000);
+    const narrative = report.clusters.find((cluster) => cluster.dimension === "narrative");
+    expect(narrative?.positions).toBe(1);
+    expect(narrative?.overLimit).toBe(false);
+  });
+
+  it("flags a slate that leans entirely on favorites", () => {
+    const report = analyzePortfolioRisk(
+      [
+        position({ id: "a", gameId: "g1", sport: "nba", team: "Lakers", stake: 8, americanOdds: -130 }),
+        position({ id: "b", gameId: "g2", sport: "nfl", team: "Chiefs", stake: 8, americanOdds: -145 }),
+        position({ id: "c", gameId: "g3", sport: "mlb", team: "Dodgers", stake: 8, americanOdds: -120 }),
+      ],
+      1000,
+    );
+
+    expect(report.warnings.some((warning) => warning.code === "narrative:favorite")).toBe(true);
+  });
+
+  it("keeps expected value signed with the edge", () => {
+    const good = analyzePortfolioRisk([position({ id: "a", modelProb: 0.62, americanOdds: -110 })], 1000);
+    const bad = analyzePortfolioRisk([position({ id: "a", modelProb: 0.4, americanOdds: -110 })], 1000);
+    expect(good.expectedValue).toBeGreaterThan(0);
+    expect(bad.expectedValue).toBeLessThan(0);
+  });
+});

--- a/src/lib/portfolioRisk.ts
+++ b/src/lib/portfolioRisk.ts
@@ -1,0 +1,375 @@
+import { americanToDecimal } from "@/lib/predictions";
+import type { RiskProfile } from "@/lib/profile";
+
+/**
+ * Portfolio Risk View — slate-wide correlated exposure.
+ *
+ * A slate of individually-sized Kelly bets is not a portfolio. Three bets on the
+ * same game, or six bets on the same night's favorites, are closer to one big bet
+ * than to six small ones. This module groups the desk by team, game, sport, and
+ * favorite/underdog narrative, prices the correlation between positions, and
+ * returns a stake haircut that brings every cluster back under its limit.
+ */
+
+export interface RiskPosition {
+  id: string;
+  gameId: string;
+  sport: string;
+  sportLabel: string;
+  /** Recommended side */
+  team: string;
+  opponent: string;
+  side: "Home" | "Away" | "Draw";
+  /** Suggested stake in bankroll currency */
+  stake: number;
+  modelProb: number;
+  americanOdds: number;
+}
+
+export type ExposureDimension = "team" | "game" | "sport" | "narrative";
+
+export interface ExposureCluster {
+  key: string;
+  label: string;
+  dimension: ExposureDimension;
+  positions: number;
+  stake: number;
+  bankrollPct: number;
+  limitPct: number;
+  overLimit: boolean;
+}
+
+export interface RiskWarning {
+  code: string;
+  severity: "high" | "medium";
+  message: string;
+}
+
+export interface ScaledPosition {
+  id: string;
+  stake: number;
+  /** Reduction forced by the cluster limits this position belongs to (0–1) */
+  limitScale: number;
+  suggestedStake: number;
+}
+
+export interface PortfolioRiskReport {
+  bankroll: number;
+  positions: number;
+  totalStake: number;
+  exposurePct: number;
+  expectedValue: number;
+  /** Stake-weighted 1σ P&L swing if positions were independent */
+  independentSigma: number;
+  /** Same, with the correlation matrix applied */
+  correlatedSigma: number;
+  /** correlatedSigma / independentSigma — above 1 means correlation is inflating risk */
+  correlationMultiple: number;
+  oneSigmaSwingPct: number;
+  /** 0–100, from the Herfindahl index of game-level stake weights */
+  diversificationScore: number;
+  clusters: ExposureCluster[];
+  topCluster: ExposureCluster | null;
+  warnings: RiskWarning[];
+  /** Blanket scale applied on top of the limit scale when correlation is elevated */
+  correlationScale: number;
+  scaledPositions: ScaledPosition[];
+  suggestedTotalStake: number;
+  /** Percentage of total stake the plan trims */
+  haircutPct: number;
+}
+
+export interface RiskLimits {
+  /** Max % of bankroll on one team */
+  teamPct: number;
+  /** Max % of bankroll on one game */
+  gamePct: number;
+  /** Max % of bankroll on one sport */
+  sportPct: number;
+  /** Max % of bankroll on the whole slate */
+  totalPct: number;
+  /** Max share of total stake pointed at one narrative before it is flagged */
+  narrativeShare: number;
+}
+
+export const RISK_LIMITS: Record<RiskProfile, RiskLimits> = {
+  conservative: { teamPct: 2, gamePct: 3, sportPct: 7, totalPct: 10, narrativeShare: 0.55 },
+  balanced: { teamPct: 3, gamePct: 4, sportPct: 10, totalPct: 15, narrativeShare: 0.65 },
+  aggressive: { teamPct: 5, gamePct: 6, sportPct: 15, totalPct: 25, narrativeShare: 0.75 },
+};
+
+/**
+ * Any multi-bet slate carries some shared risk, so a haircut that fires at the
+ * first sign of correlation would just shrink every plan. Only trim once
+ * correlated sigma runs this far past the independent case.
+ */
+const CORRELATION_TOLERANCE = 1.25;
+
+function clamp(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(value, max));
+}
+
+function round(value: number, digits = 2) {
+  return Number(value.toFixed(digits));
+}
+
+function narrativeOf(position: RiskPosition): { key: string; label: string } {
+  if (position.side === "Draw") return { key: "draw", label: "Draw prices" };
+  return position.americanOdds < 0
+    ? { key: "favorite", label: "Favorites" }
+    : { key: "underdog", label: "Underdogs" };
+}
+
+/**
+ * Assumed correlation between two positions' outcomes.
+ *
+ * These are deliberately coarse — the point is to stop a desk from treating six
+ * bets on one slate as six independent coin flips, not to claim a precise rho.
+ */
+export function positionCorrelation(a: RiskPosition, b: RiskPosition): number {
+  if (a.id === b.id) return 1;
+
+  if (a.gameId === b.gameId) {
+    // Same side of the same game twice: effectively one position.
+    if (a.team === b.team) return 1;
+    // Opposite sides of the same game hedge each other.
+    if (a.side !== b.side) return -1;
+    return 0.6;
+  }
+
+  // A team appearing in two different games moves together across both.
+  if (a.team === b.team) return 0.5;
+
+  // Same league on the same slate shares refs, weather, market sentiment, and
+  // whatever the model is currently getting wrong about that sport.
+  if (a.sport === b.sport) return 0.15;
+
+  return 0.05;
+}
+
+/** 1σ of a single position's P&L: stake * decimalOdds * sqrt(p(1-p)). */
+function positionSigma(position: RiskPosition): number {
+  const p = clamp(position.modelProb, 0.01, 0.99);
+  const decimal = americanToDecimal(position.americanOdds);
+  return Math.abs(position.stake) * decimal * Math.sqrt(p * (1 - p));
+}
+
+function positionEv(position: RiskPosition): number {
+  const p = clamp(position.modelProb, 0.01, 0.99);
+  const profitMultiple = americanToDecimal(position.americanOdds) - 1;
+  return position.stake * (p * profitMultiple - (1 - p));
+}
+
+function buildClusters(
+  positions: RiskPosition[],
+  bankroll: number,
+  limits: RiskLimits,
+  totalStake: number,
+): ExposureCluster[] {
+  const buckets = new Map<string, { label: string; dimension: ExposureDimension; stake: number; positions: number }>();
+
+  const add = (key: string, label: string, dimension: ExposureDimension, stake: number) => {
+    const existing = buckets.get(key);
+    if (existing) {
+      existing.stake += stake;
+      existing.positions += 1;
+      return;
+    }
+    buckets.set(key, { label, dimension, stake, positions: 1 });
+  };
+
+  for (const position of positions) {
+    const narrative = narrativeOf(position);
+    add(`team:${position.team}`, position.team, "team", position.stake);
+    add(`game:${position.gameId}`, `${position.team} vs ${position.opponent}`, "game", position.stake);
+    add(`sport:${position.sport}`, position.sportLabel, "sport", position.stake);
+    add(`narrative:${narrative.key}`, narrative.label, "narrative", position.stake);
+  }
+
+  const limitFor = (dimension: ExposureDimension) => {
+    if (dimension === "team") return limits.teamPct;
+    if (dimension === "game") return limits.gamePct;
+    if (dimension === "sport") return limits.sportPct;
+    // Narrative is a share of the slate, expressed against bankroll for display.
+    return round(limits.narrativeShare * (totalStake / bankroll) * 100);
+  };
+
+  return Array.from(buckets.entries())
+    .map(([key, bucket]) => {
+      const bankrollPct = round((bucket.stake / bankroll) * 100);
+      const limitPct = limitFor(bucket.dimension);
+      return {
+        key,
+        label: bucket.label,
+        dimension: bucket.dimension,
+        positions: bucket.positions,
+        stake: round(bucket.stake),
+        bankrollPct,
+        limitPct,
+        // A one-position narrative bucket is just the bet itself, not a theme.
+        overLimit: bankrollPct > limitPct + 1e-9 && !(bucket.dimension === "narrative" && bucket.positions < 3),
+      };
+    })
+    .sort((a, b) => b.stake - a.stake);
+}
+
+function buildWarnings(
+  clusters: ExposureCluster[],
+  exposurePct: number,
+  limits: RiskLimits,
+  correlationMultiple: number,
+  positionCount: number,
+): RiskWarning[] {
+  const warnings: RiskWarning[] = [];
+
+  if (exposurePct > limits.totalPct) {
+    warnings.push({
+      code: "total-exposure",
+      severity: "high",
+      message: `Slate risks ${exposurePct.toFixed(1)}% of bankroll against a ${limits.totalPct}% ceiling.`,
+    });
+  }
+
+  for (const cluster of clusters.filter((entry) => entry.overLimit)) {
+    if (cluster.dimension === "narrative") {
+      warnings.push({
+        code: cluster.key,
+        severity: "medium",
+        message: `${cluster.positions} positions lean ${cluster.label.toLowerCase()} — one market read is driving the slate.`,
+      });
+      continue;
+    }
+    warnings.push({
+      code: cluster.key,
+      severity: cluster.dimension === "sport" ? "medium" : "high",
+      message: `${cluster.label} carries ${cluster.bankrollPct.toFixed(1)}% of bankroll, over the ${cluster.limitPct}% ${cluster.dimension} limit.`,
+    });
+  }
+
+  if (positionCount > 1 && correlationMultiple > CORRELATION_TOLERANCE) {
+    warnings.push({
+      code: "correlation",
+      severity: "high",
+      message: `Correlated risk is ${correlationMultiple.toFixed(2)}× the independent case — these bets lose together.`,
+    });
+  }
+
+  return warnings;
+}
+
+export function analyzePortfolioRisk(
+  positions: RiskPosition[],
+  bankroll: number,
+  riskProfile: RiskProfile = "balanced",
+  limitOverrides?: Partial<RiskLimits>,
+): PortfolioRiskReport {
+  const limits = { ...RISK_LIMITS[riskProfile], ...limitOverrides };
+  const safeBankroll = Math.max(bankroll, 1);
+  const priced = positions.filter((position) => position.stake > 0);
+
+  if (priced.length === 0) {
+    return {
+      bankroll: safeBankroll,
+      positions: 0,
+      totalStake: 0,
+      exposurePct: 0,
+      expectedValue: 0,
+      independentSigma: 0,
+      correlatedSigma: 0,
+      correlationMultiple: 1,
+      oneSigmaSwingPct: 0,
+      diversificationScore: 0,
+      clusters: [],
+      topCluster: null,
+      warnings: [],
+      correlationScale: 1,
+      scaledPositions: [],
+      suggestedTotalStake: 0,
+      haircutPct: 0,
+    };
+  }
+
+  const totalStake = priced.reduce((sum, position) => sum + position.stake, 0);
+  const exposurePct = (totalStake / safeBankroll) * 100;
+  const expectedValue = priced.reduce((sum, position) => sum + positionEv(position), 0);
+
+  const sigmas = priced.map(positionSigma);
+  const independentSigma = Math.sqrt(sigmas.reduce((sum, sigma) => sum + sigma * sigma, 0));
+
+  // Portfolio variance = ΣΣ rho(i,j) * sigma(i) * sigma(j). The heuristic rho table
+  // is not guaranteed positive semi-definite, so a hedged book can drive this below
+  // zero — floor it at zero rather than reporting an imaginary sigma.
+  let variance = 0;
+  for (let i = 0; i < priced.length; i++) {
+    for (let j = 0; j < priced.length; j++) {
+      variance += positionCorrelation(priced[i], priced[j]) * sigmas[i] * sigmas[j];
+    }
+  }
+  const correlatedSigma = Math.sqrt(Math.max(variance, 0));
+  const correlationMultiple = independentSigma > 0 ? correlatedSigma / independentSigma : 1;
+
+  const clusters = buildClusters(priced, safeBankroll, limits, totalStake);
+
+  // Diversification reads game-level weights: two bets inside one game are one bet.
+  const gameClusters = clusters.filter((cluster) => cluster.dimension === "game");
+  const herfindahl = gameClusters.reduce((sum, cluster) => {
+    const weight = cluster.stake / totalStake;
+    return sum + weight * weight;
+  }, 0);
+  const diversificationScore = Math.round(clamp((1 - herfindahl) * 100, 0, 100));
+
+  const warnings = buildWarnings(clusters, exposurePct, limits, correlationMultiple, priced.length);
+
+  const clusterByKey = new Map(clusters.map((cluster) => [cluster.key, cluster]));
+  const totalLimitStake = (limits.totalPct / 100) * safeBankroll;
+
+  const scaledPositions: ScaledPosition[] = priced.map((position) => {
+    const keys = [`team:${position.team}`, `game:${position.gameId}`, `sport:${position.sport}`];
+    let limitScale = totalStake > totalLimitStake ? totalLimitStake / totalStake : 1;
+
+    for (const key of keys) {
+      const cluster = clusterByKey.get(key);
+      if (!cluster || !cluster.overLimit || cluster.stake <= 0) continue;
+      limitScale = Math.min(limitScale, ((cluster.limitPct / 100) * safeBankroll) / cluster.stake);
+    }
+
+    limitScale = clamp(limitScale, 0, 1);
+    return {
+      id: position.id,
+      stake: round(position.stake),
+      limitScale: round(limitScale, 4),
+      suggestedStake: round(position.stake * limitScale),
+    };
+  });
+
+  // Correlation haircut rides on top of the limit scale so both reductions stay
+  // separately explainable on the card. It scales back toward the tolerance, not
+  // toward zero correlation — a slate of independent bets is not the target.
+  const correlationScale =
+    correlationMultiple > CORRELATION_TOLERANCE
+      ? round(clamp(CORRELATION_TOLERANCE / correlationMultiple, 0.6, 1), 4)
+      : 1;
+  const suggestedTotalStake = round(
+    scaledPositions.reduce((sum, position) => sum + position.suggestedStake, 0) * correlationScale,
+  );
+
+  return {
+    bankroll: safeBankroll,
+    positions: priced.length,
+    totalStake: round(totalStake),
+    exposurePct: round(exposurePct),
+    expectedValue: round(expectedValue),
+    independentSigma: round(independentSigma),
+    correlatedSigma: round(correlatedSigma),
+    correlationMultiple: round(correlationMultiple, 3),
+    oneSigmaSwingPct: round((correlatedSigma / safeBankroll) * 100),
+    diversificationScore,
+    clusters,
+    topCluster: clusters.find((cluster) => cluster.dimension !== "narrative") ?? null,
+    warnings,
+    correlationScale,
+    scaledPositions,
+    suggestedTotalStake,
+    haircutPct: totalStake > 0 ? round(clamp((1 - suggestedTotalStake / totalStake) * 100, 0, 100), 1) : 0,
+  };
+}

--- a/src/pages/DailyPicks.tsx
+++ b/src/pages/DailyPicks.tsx
@@ -26,6 +26,7 @@ import AccessSessionDialog from "@/components/AccessSessionDialog";
 import PaymentOptionDialog from "@/components/PaymentOptionDialog";
 import { useToast } from "@/components/ui/use-toast";
 import KellySimulator from "@/components/KellySimulator";
+import PortfolioRiskView from "@/components/PortfolioRiskView";
 import {
   getAuthChangeEventName,
   getCurrentSiteUser,
@@ -47,6 +48,7 @@ import { getCurrentUserProfile } from "@/lib/profile";
 import { buildLinePath, closeLineValuePts, closeVerdict, formatCloseBadge, formatPathLabel } from "@/lib/linePath";
 import { stressKellyStake } from "@/lib/kellyStress";
 import { deskRowsFromPicks, downloadCsv, toCsv } from "@/lib/exportDesk";
+import type { RiskPosition } from "@/lib/portfolioRisk";
 import { Slider } from "@/components/ui/slider";
 
 interface PickEntry {
@@ -795,6 +797,30 @@ export default function DailyPicks() {
   const valueBets = filteredGames.filter((entry) => entry.prediction.valueBet).length;
   const sportsShown = Array.from(new Set(games.map((game) => game.sportLabel)));
 
+  // Risk is measured over the bets this user can actually place — the open board
+  // alone until premium unlocks the rest of the slate.
+  const riskPositions = useMemo<RiskPosition[]>(() => {
+    const actionable = hasPremiumBoard ? filteredGames : freePicks;
+    return actionable.flatMap(({ game, prediction }) => {
+      const bet = prediction.valueBet;
+      if (!bet || bet.suggestedBet <= 0) return [];
+      return [
+        {
+          id: `${game.id}:${bet.team}`,
+          gameId: game.id,
+          sport: game.sport,
+          sportLabel: game.sportLabel,
+          team: bet.team,
+          opponent: bet.team === game.homeTeam ? game.awayTeam : game.homeTeam,
+          side: bet.location,
+          stake: bet.suggestedBet,
+          modelProb: bet.modelProb,
+          americanOdds: bet.odds,
+        },
+      ];
+    });
+  }, [filteredGames, freePicks, hasPremiumBoard]);
+
   const exportDesk = () => {
     const csv = toCsv(deskRowsFromPicks(filteredGames));
     if (!csv) {
@@ -1080,6 +1106,13 @@ export default function DailyPicks() {
                 bankroll={userBankroll}
                 kellyFraction={userKellyFraction}
                 riskLabel={userProfile?.riskProfile === "conservative" ? "Conservative" : userProfile?.riskProfile === "aggressive" ? "Aggressive" : "Balanced"}
+              />
+              <PortfolioRiskView
+                positions={riskPositions}
+                bankroll={userBankroll}
+                riskProfile={userProfile?.riskProfile ?? "balanced"}
+                locked={!hasPremiumBoard}
+                onUnlock={() => setShowPaymentOptionModal(true)}
               />
               <KellySimulator />
             </div>


### PR DESCRIPTION
Ships roadmap premium surface #4 from `docs/advantage_operating_system.md`:

> `Portfolio Risk View` — Show correlated exposure across teams, games, and slates. Stop over-betting one narrative in different wrappers.

## The gap

Per-bet Kelly sizing prices each bet as if it were the only bet on the board. Three bets on one game, or six on one night's favorites, are closer to one large position than to six small ones — and nothing on the desk currently says so.

## What this adds

A **Portfolio Risk View** panel in the `/daily-picks` sidebar that reads the whole filtered desk at once:

- **Exposure buckets** — every position is grouped by team, game, sport, and narrative (favorites / underdogs / draws), each with a limit driven by the user's risk profile (conservative / balanced / aggressive).
- **Correlated risk** — position sigma is `stake × decimalOdds × sqrt(p(1-p))`; portfolio sigma applies a coarse rho table (same side same game `1.0`, opposite sides `-1.0`, same team `0.5`, same league `0.15`, cross-sport `0.05`). The reported `correlationMultiple` is correlated sigma over independent sigma — the number per-bet Kelly cannot see.
- **Diversification score** — `100 × (1 - HHI)` over *game-level* stake weights, so two bets inside one game count as one.
- **De-correlated plan** — a per-position limit scale that pulls every over-limit bucket back inside its cap, plus a blanket correlation scale that engages only past a `1.25` tolerance. The two reductions stay separate so each is explainable on the card.

## Design decisions worth reviewing

- **Risk is measured over bets the user can actually place** — the open board alone until premium unlocks the slate. A free user's exposure number describes their real actionable slate, not one they cannot see. The bucket breakdown and haircut plan sit behind `premium_board`; the headline metrics stay open, matching the existing "proof near the paywall" pattern.
- **The rho table is a heuristic, not a fitted covariance matrix**, so it is not guaranteed positive semi-definite. A hedged book can drive the variance sum negative; it is floored at zero rather than reporting an imaginary sigma. The card states the assumptions so the user can discount them.
- **The correlation haircut only fires past a tolerance.** Any multi-bet slate carries some shared risk — a haircut that engaged at the first sign of correlation would just shrink every plan, so it scales back toward the tolerance rather than toward zero correlation.
- **A narrative bucket under three positions is not a theme**, so it is neither flagged nor charted. A limit that is not being enforced is never displayed.
- An empty desk renders an empty panel rather than invented exposure.

## Files

| File | Role |
|------|------|
| `src/lib/portfolioRisk.ts` | Pure risk engine — buckets, correlation, haircut |
| `src/lib/portfolioRisk.test.ts` | 13 tests |
| `src/components/PortfolioRiskView.tsx` | Presentation, premium gating |
| `src/pages/DailyPicks.tsx` | Maps desk value bets to positions, renders panel |
| `docs/portfolio_risk.md` | Schema, formulas, rho table, next steps |

## Verification

- `npm test` — 49 passed (11 files), including 13 new
- `npm run lint` — 0 errors (2 pre-existing warnings in `ui/badge.tsx`, `ui/button.tsx`)
- `npm run build` — clean
- Rendered in a browser against a stubbed slate with a deliberate concentration (two Lakers games plus an NBA favorites stack). The panel correctly flagged the Celtics team bucket at 4.7% over the 3% limit and the shared game bucket over 4%, and proposed trimming $94 → $77. Its `$94 across 3 positions` agrees with the page's own "Total suggested stake" stat.

Note: `npx tsc -p tsconfig.app.json` reports `TS5103: Invalid value for '--ignoreDeprecations'` — this reproduces on `main` and is unrelated to this change.

Two tests failed on the first run and caught real bugs, both fixed here: the narrative warning code was double-prefixed (`narrative:narrative:favorite`), and the correlation haircut originally applied to any multi-position slate rather than only concentrated ones.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uu6R2oWB7x9mLcznV8JPaV)_