### PR TITLE
fix: restore backtest console, cut recharts from homepage, unbreak CI typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Build mode (-b), not `tsc --noEmit`: the root tsconfig is a solution file
+      # with `"files": []`, and plain `tsc` does not follow project references —
+      # so the old command typechecked zero files and always passed.
       - name: Type check
-        run: npx tsc --noEmit
+        run: npx tsc -b --force
 
       - name: Lint
         run: npm run lint

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ dist-ssr
 *.pem
 *.key
 .netlify
+
+# TypeScript incremental build info (emitted by `tsc -b`)
+*.tsbuildinfo

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,7 +25,7 @@ export default tseslint.config(
         "warn",
         { allowConstantExport: true },
       ],
-      "@typescript-eslint/no-unused-vars": "off",
+      "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_", varsIgnorePattern: "^_", caughtErrors: "none" }],
     },
   }
 );

--- a/src/components/KellySimulator.tsx
+++ b/src/components/KellySimulator.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Slider } from "@/components/ui/slider";
 import { Badge } from "@/components/ui/badge";
-import { Play, RotateCcw, HelpCircle, TrendingUp, ChevronDown, ChevronUp } from "lucide-react";
+import { RotateCcw, HelpCircle, TrendingUp, ChevronDown, ChevronUp } from "lucide-react";
 import {
   Tooltip,
   TooltipContent,

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -15,13 +15,6 @@ type ToasterToast = ToastProps & {
   action?: ToastActionElement
 }
 
-const actionTypes = {
-  ADD_TOAST: "ADD_TOAST",
-  UPDATE_TOAST: "UPDATE_TOAST",
-  DISMISS_TOAST: "DISMISS_TOAST",
-  REMOVE_TOAST: "REMOVE_TOAST",
-} as const
-
 let count = 0
 
 function genId() {
@@ -29,7 +22,14 @@ function genId() {
   return count.toString()
 }
 
-type ActionType = typeof actionTypes
+// Type-only: the former `actionTypes` const was never read at runtime, so it
+// shipped a dead object to the client just to be fed to `typeof`.
+type ActionType = {
+  ADD_TOAST: "ADD_TOAST"
+  UPDATE_TOAST: "UPDATE_TOAST"
+  DISMISS_TOAST: "DISMISS_TOAST"
+  REMOVE_TOAST: "REMOVE_TOAST"
+}
 
 type Action =
   | {

--- a/src/lib/predictions.test.ts
+++ b/src/lib/predictions.test.ts
@@ -7,6 +7,8 @@ import {
   calculateExecutionAdjustedEdge,
   predictSoccer,
   getWorldCupRating,
+  generateBacktestData,
+  calculateBacktestSummary,
 } from "./predictions";
 
 describe("odds conversions", () => {
@@ -98,5 +100,43 @@ describe("predictSoccer (World Cup 3-way model)", () => {
     const m = predictSoccer(getWorldCupRating("Wakanda"), getWorldCupRating("Atlantis"));
     // Two unknowns ⇒ only the home-advantage tilt separates them.
     expect(Math.abs(m.homeProb - m.awayProb)).toBeLessThan(0.15);
+  });
+});
+
+describe("backtest simulation", () => {
+  // The market line used to be priced off the model's own probability, so juice
+  // pushed implied probability above it on every game. Edge was always negative,
+  // the `edge > 3` gate never opened, and the console rendered all zeros.
+  it("places bets — the market must not be priced off the model's own number", () => {
+    const results = generateBacktestData("nba", 6);
+    const bets = results.filter((row) => row.betPlaced);
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(bets.length).toBeGreaterThan(0);
+  });
+
+  it("produces a summary with a populated monthly series", () => {
+    const summary = calculateBacktestSummary(generateBacktestData("nba", 6));
+
+    expect(summary.totalBets).toBeGreaterThan(0);
+    expect(summary.profitByMonth.length).toBeGreaterThan(0);
+    expect(Number.isFinite(summary.roi)).toBe(true);
+    expect(Number.isFinite(summary.sharpeRatio)).toBe(true);
+  });
+
+  it("stays deterministic for a given sport and window", () => {
+    const a = calculateBacktestSummary(generateBacktestData("nba", 6));
+    const b = calculateBacktestSummary(generateBacktestData("nba", 6));
+    expect(a.totalProfit).toBe(b.totalProfit);
+    expect(a.totalBets).toBe(b.totalBets);
+  });
+
+  it("does not tilt the simulation toward a winning record", () => {
+    // Symmetric market disagreement plus juice: results must be free to go
+    // negative, never engineered into a guaranteed upward curve.
+    const sports = (["nba", "nfl", "mlb"] as const).map((sport) =>
+      calculateBacktestSummary(generateBacktestData(sport, 6)),
+    );
+    expect(sports.some((summary) => summary.totalProfit < 0)).toBe(true);
   });
 });

--- a/src/lib/predictions.ts
+++ b/src/lib/predictions.ts
@@ -1009,8 +1009,14 @@ export function generateBacktestData(sport: Sport, months: number = 6): Backtest
       const actualWinner = actualHomeWin ? homeTeam : awayTeam;
       const correct = prediction === actualWinner;
       
-      // Generate realistic odds
-      const odds = generateOdds(homeProb > 0.5 ? homeProb : 1 - homeProb);
+      // Price the market off its own read of the matchup, not off the model's
+      // number. Pricing from modelProb meant impliedProb always landed above it
+      // once juice was added, so edge was negative on every game and the
+      // simulation could never place a bet — the console rendered all zeros.
+      // Disagreement is symmetric, so the juice still drags results downward and
+      // a losing run stays possible.
+      const marketProb = clampValue(modelProb + (rng() - 0.5) * 0.12, 0.05, 0.95);
+      const odds = generateOdds(marketProb);
       const impliedProb = americanToImpliedProb(odds);
       const edge = (modelProb - impliedProb) * 100;
       
@@ -1199,7 +1205,6 @@ export function generatePerformanceData(): PerformanceData {
     const winRate = wins / picks;
     
     // Calculate profit assuming average odds of -110
-    const avgOdds = -110;
     const winPayout = wins * (100 / 110); // Win at -110 odds
     const lossAmount = losses * 1; // Lose 1 unit per loss
     const profit = (winPayout - lossAmount) * 100; // In dollars assuming $100 units

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -237,36 +237,6 @@ function isConfiguredPaymentLink(url: string): boolean {
   }
 }
 
-async function createCheckoutSession(type: CheckoutMode): Promise<string> {
-  const siteUser = getCurrentSiteUser();
-  const response = await fetch("/api/create-checkout-session", {
-    method: "POST",
-    credentials: "include",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-    },
-    // Email/id are hints only — server prefers the authenticated session cookie.
-    body: JSON.stringify({
-      mode: type,
-      customerEmail: siteUser?.email,
-      clientReferenceId: siteUser?.id,
-    }),
-  });
-
-  if (!response.ok) {
-    const message = await readApiError(response, "Unable to start Stripe checkout.");
-    throw new Error(message || "Unable to start Stripe checkout.");
-  }
-
-  const data = (await response.json()) as CheckoutSessionResponse;
-  if (!data.url) {
-    throw new Error("Stripe checkout session did not return a redirect URL.");
-  }
-
-  return data.url;
-}
-
 async function verifyCheckoutSession(sessionId: string): Promise<CheckoutSessionStatusResponse> {
   const response = await fetch(`/api/checkout-session?session_id=${encodeURIComponent(sessionId)}`, {
     credentials: "include",

--- a/src/pages/DailyPicks.tsx
+++ b/src/pages/DailyPicks.tsx
@@ -1,11 +1,10 @@
-import { useEffect, useMemo, useState, useRef, useCallback } from "react";
+import { useEffect, useMemo, useState, useRef } from "react";
 import { Link } from "react-router-dom";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Activity,
   ArrowRight,
-  BarChart2,
   Calendar,
   ChevronLeft,
   Clock,
@@ -39,7 +38,6 @@ import {
   getCurrentCryptoAccount,
   hasFeatureAccess,
   redirectToCheckout,
-  signOutAccessSession,
 } from "@/lib/stripe";
 import { analyzeGame, formatEdge, formatOdds, formatProb, type GamePrediction } from "@/lib/predictions";
 import { fetchLiveGamesForSports, type LiveMarketGame } from "@/lib/liveSports";

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -48,7 +48,6 @@ import { fetchLiveGamesForSport, type LiveMarketGame } from "@/lib/liveSports";
 import {
   getAuthChangeEventName,
   getCurrentSiteUser,
-  signOutSiteUser,
   type SiteUser,
 } from "@/lib/auth";
 import {
@@ -187,51 +186,72 @@ function SectionHeader({
   );
 }
 
-// Recharts is heavy (~95KB). Lazy-load it so it splits into its own chunk and
-// stays off the homepage's first-paint critical path.
-const MiniChart = lazy(() =>
-  import("recharts").then((mod) => {
-    const { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } = mod;
-    return {
-      default: function MiniChart({ data }: { data: Array<{ name: string; value: number }> }) {
-        const values = data.map((item) => item.value);
-        const min = Math.min(...values);
-        const max = Math.max(...values);
-        const range = Math.max(max - min, 1);
-        const points = data
-          .map((item, index) => {
-            const x = data.length === 1 ? 0 : (index / (data.length - 1)) * 100;
-            const y = 88 - ((item.value - min) / range) * 72;
-            return `${x},${y}`;
-          })
-          .join(" ");
-        return (
-          <div className="h-40 w-full min-w-0">
-            <svg viewBox="0 0 100 100" preserveAspectRatio="none" className="h-full w-full overflow-visible">
-              <defs>
-                <linearGradient id="proof-curve-fill" x1="0" x2="0" y1="0" y2="1">
-                  <stop offset="0%" stopColor="rgba(34,211,238,0.24)" />
-                  <stop offset="100%" stopColor="rgba(34,211,238,0)" />
-                </linearGradient>
-              </defs>
-              <polyline points={`0,96 ${points} 100,96`} fill="url(#proof-curve-fill)" stroke="none" />
-              <polyline points={points} fill="none" stroke="#22d3ee" strokeWidth="2.4" vectorEffect="non-scaling-stroke" />
-              {data.map((item, index) => {
-                const x = data.length === 1 ? 0 : (index / (data.length - 1)) * 100;
-                const y = 88 - ((item.value - min) / range) * 72;
-                return <circle key={item.name} cx={x} cy={y} r="1.6" fill="#34d399" vectorEffect="non-scaling-stroke" />;
-              })}
-            </svg>
-            <div className="mt-2 flex justify-between text-[11px] text-slate-600">
-              <span>{data[0]?.name}</span>
-              <span>{data[data.length - 1]?.name}</span>
-            </div>
-          </div>
-        );
-      },
-    };
-  }),
-);
+// Backtest console summary tile. Referenced by the console since it shipped but
+// never actually defined, so every run crashed the page on render.
+function StatTile({
+  label,
+  value,
+  detail,
+  accent = "text-white",
+}: {
+  label: string;
+  value: string;
+  detail: string;
+  accent?: string;
+}) {
+  return (
+    <div className="rounded-lg border border-white/10 bg-slate-950/50 px-4 py-3">
+      <div className="text-[9px] font-semibold uppercase tracking-[0.16em] text-slate-600">{label}</div>
+      <div className={`mt-2 font-mono text-xl font-semibold tabular-nums ${accent}`}>{value}</div>
+      <div className="mt-1 text-[11px] leading-4 text-slate-500">{detail}</div>
+    </div>
+  );
+}
+
+// Hand-rolled SVG on purpose: this sparkline needs a fill, a stroke, and dots,
+// which is not worth a charting runtime. It used to lazy-load recharts and then
+// render none of it, which pulled ~150KB gzip onto the homepage's critical path
+// and — with no local Suspense boundary — dropped the whole page to the
+// route-level fallback until that chunk landed.
+function MiniChart({ data }: { data: Array<{ name: string; value: number }> }) {
+  const values = data.map((item) => item.value);
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = Math.max(max - min, 1);
+  const pointAt = (item: { value: number }, index: number) => ({
+    x: data.length === 1 ? 0 : (index / (data.length - 1)) * 100,
+    y: 88 - ((item.value - min) / range) * 72,
+  });
+  const points = data
+    .map((item, index) => {
+      const { x, y } = pointAt(item, index);
+      return `${x},${y}`;
+    })
+    .join(" ");
+
+  return (
+    <div className="h-40 w-full min-w-0">
+      <svg viewBox="0 0 100 100" preserveAspectRatio="none" className="h-full w-full overflow-visible">
+        <defs>
+          <linearGradient id="proof-curve-fill" x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stopColor="rgba(34,211,238,0.24)" />
+            <stop offset="100%" stopColor="rgba(34,211,238,0)" />
+          </linearGradient>
+        </defs>
+        <polyline points={`0,96 ${points} 100,96`} fill="url(#proof-curve-fill)" stroke="none" />
+        <polyline points={points} fill="none" stroke="#22d3ee" strokeWidth="2.4" vectorEffect="non-scaling-stroke" />
+        {data.map((item, index) => {
+          const { x, y } = pointAt(item, index);
+          return <circle key={item.name} cx={x} cy={y} r="1.6" fill="#34d399" vectorEffect="non-scaling-stroke" />;
+        })}
+      </svg>
+      <div className="mt-2 flex justify-between text-[11px] text-slate-600">
+        <span>{data[0]?.name}</span>
+        <span>{data[data.length - 1]?.name}</span>
+      </div>
+    </div>
+  );
+}
 
 function formatLineDelta(delta?: number) {
   if (delta === undefined || Number.isNaN(delta)) return "Flat";
@@ -268,7 +288,8 @@ function Index() {
   // fabricated-fresh-on-every-render curve. The real settled record is the ledger.
   const [performanceData, setPerformanceData] = useState<PerformanceData | null>(() => generatePerformanceData());
   const [access, setAccess] = useState(getAccessState());
-  const [cryptoAccount, setCryptoAccount] = useState(getCurrentCryptoAccount());
+  // Value is unread — this state exists only to re-render on access changes.
+  const [, setCryptoAccount] = useState(getCurrentCryptoAccount());
   const [siteUser, setSiteUser] = useState<SiteUser | null>(getCurrentSiteUser());
   const [billingStatus, setBillingStatus] = useState<BillingStatus | null>(null);
   const [showCryptoModal, setShowCryptoModal] = useState(false);

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2021", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
 
@@ -21,7 +21,7 @@
     "noImplicitAny": false,
     "noFallthroughCasesInSwitch": false,
 
-    "ignoreDeprecations": "6.0",
+    "ignoreDeprecations": "5.0",
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]


### PR DESCRIPTION
"Improve the site" was open-ended, so rather than add a feature I went looking for defects. Turning on one disabled lint rule surfaced a chain of them — each one hidden by the last.

## 1. The homepage downloaded a charting library it never used

`Index.tsx`'s `MiniChart` lazy-imported recharts, destructured seven components from it — `Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis` — and then rendered a **hand-rolled `<svg>`** using none of them.

Worse, it had no local `Suspense` boundary, so the nearest one was the route-level fallback in `App.tsx`. On the homepage's first paint the **entire page dropped to the "Loading desk" screen** while ~150 KB gzip of recharts downloaded, purely to draw a polyline.

`MiniChart` is now a plain synchronous component. Recharts still legitimately serves `BacktestChart` and `Leaderboard`, and now tree-shakes into a 336 KB chunk that loads only when those render.

| Homepage critical path | Before | After |
|---|---|---|
| Raw | ~954 KB | 394 KB |
| Gzip | ~272 KB | 122 KB |

Verified in a browser: zero recharts requests on the homepage, no route-level fallback flash, sparkline pixel-identical.

## 2. CI's typecheck was checking zero files

The root `tsconfig.json` is a solution file with `"files": []` and project references. Plain `tsc --noEmit` **does not follow project references** — so the CI "Type check" step compiled nothing and passed vacuously on every PR.

`tsconfig.app.json` couldn't be checked directly either: `ignoreDeprecations: "6.0"` is invalid on TypeScript 5.9 (`TS5103`), so any direct invocation errored out before reporting anything.

CI now runs `tsc -b --force`, which follows the references. With typechecking actually running for the first time, two real errors appeared:

## 3. The backtest console crashed the homepage

`StatTile` was referenced **five times** in the backtest console but **never defined or imported anywhere**. Clicking "Run illustrative backtest" threw `StatTile is not defined` and took the page down. Confirmed present on `main` — this is live on production. Restored in the page's existing stat-tile idiom.

Also: `String.replaceAll` (used in `exportDesk.ts` and `liveSports.ts`) needs `lib: es2021`; `lib` was pinned to `ES2020`.

## 4. The backtest simulation could never place a bet

With the crash fixed, the console rendered for the first time — and showed 360 games, **$0 profit, 0% ROI, 0.00 Sharpe, and an empty chart**.

`generateOdds()` priced the market off *the model's own probability* and then added juice. So `impliedProb` always landed above `modelProb`, `edge` was negative on every single game, and the `edge > 3` gate never opened. Structurally impossible to bet.

The market now prices off its own read of the matchup. Disagreement is **symmetric**, so juice still drags results downward and a losing run stays possible — this is a proof surface, not a marketing curve. The NBA six-month run settles at **−$80 / −2.0% ROI**, and a test asserts the simulation is not tilted toward a winning record.

## 5. Dead code the rule found

- `createCheckoutSession` in `stripe.ts` — an unused duplicate of the live `redirectToCheckout`, missing the trial flag and the production fallback guard the live path has. Removed so nobody wires up the unsafe one.
- `actionTypes` in `use-toast.ts` — a runtime object shipped to the client only to be fed to `typeof`. Now type-only.
- Five unused imports (`Play`, `useCallback`, `BarChart2`, `signOutAccessSession`, `signOutSiteUser`), one unread state value, one dead const.

`@typescript-eslint/no-unused-vars` is now `warn` with `^_` escape hatches, so this class of defect surfaces instead of accumulating.

## Verification

- **Typecheck** — `npx tsc -b --force` passes; previously checked 0 files
- **Lint** — 0 errors, 2 warnings (both pre-existing `react-refresh` ones)
- **Tests** — 53 passed, including 4 new backtest regression tests
- **Build** — clean
- **Browser** — homepage renders with no recharts request and no fallback flash; backtest console runs, renders all five stat tiles, and lazy-loads recharts only on click (7 monthly bars, mixed positive/negative)

## Reviewer note

Item 4 changes what the illustrative backtest displays — from all zeros to real simulated numbers that can be negative. The section is explicitly labelled "Deterministic illustrative simulation — not historical results", and the change is deliberately unbiased, but it is a product-visible behavior change and worth a look.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uu6R2oWB7x9mLcznV8JPaV)_