### PR TITLE
Site fixes: mobile nav, price drift, soft 404, per-route SEO metadata, a11y

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,22 @@
     <link rel="manifest" href="/site.webmanifest" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <!--
+      Fonts load off the critical path. A plain stylesheet link here blocks first
+      paint on a third-party round trip; `media="print"` lets the browser fetch it
+      at low priority, then `onload` promotes it to `all`. `display=swap` means
+      text is readable in the fallback face the whole time, and the <noscript>
+      copy keeps the webfont for script-less clients.
+    -->
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap"
+      media="print"
+      onload="this.media='all';this.onload=null;"
+    >
+    <noscript>
+      <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    </noscript>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
@@ -48,14 +63,14 @@
           },
           {
             "@type": "Offer",
-            "name": "Event Pass",
-            "price": "10",
+            "name": "Pro Monthly",
+            "price": "15",
             "priceCurrency": "USD"
           },
           {
             "@type": "Offer",
-            "name": "Pro Monthly",
-            "price": "19",
+            "name": "Event Pass",
+            "price": "10",
             "priceCurrency": "USD"
           }
         ]

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,31 +2,31 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://aiadvantagesports.com/</loc>
-    <lastmod>2026-06-11</lastmod>
+    <lastmod>2026-07-28</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://aiadvantagesports.com/daily-picks</loc>
-    <lastmod>2026-06-11</lastmod>
+    <lastmod>2026-07-28</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://aiadvantagesports.com/leaderboard</loc>
-    <lastmod>2026-06-11</lastmod>
+    <lastmod>2026-07-28</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://aiadvantagesports.com/login</loc>
-    <lastmod>2026-06-11</lastmod>
+    <lastmod>2026-07-28</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://aiadvantagesports.com/signup</loc>
-    <lastmod>2026-06-11</lastmod>
+    <lastmod>2026-07-28</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.4</priority>
   </url>

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -14,6 +14,13 @@ import { dirname, join } from "node:path";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const indexPath = join(here, "..", "dist", "index.html");
+const pricingPath = join(here, "..", "src", "data", "pricing.json");
+
+// Prices come from the same JSON the pricing cards render from, so the
+// prerendered copy and the JSON-LD offers can never advertise a number that
+// checkout does not charge.
+const pricing = JSON.parse(await readFile(pricingPath, "utf8"));
+const planById = (id) => pricing.plans.find((plan) => plan.id === id);
 
 const sections = [
   {
@@ -39,11 +46,10 @@ const valueProps = [
   ["Kelly sizing", "Quarter-Kelly stake guidance keeps conviction from turning reckless."],
 ];
 
-const pricing = [
-  ["Free Desk", "$0", "Live board, model leans, and the public proof ledger."],
-  ["Event Pass", "$10", "Unlock the full execution board for a single slate."],
-  ["Pro Monthly", "$19", "Deeper boards, historical ledgers, and workflow tools."],
-];
+const pricingRows = ["free", "one-time", "premium"]
+  .map(planById)
+  .filter(Boolean)
+  .map((plan) => [plan.name, `$${plan.price}`, plan.seoBlurb]);
 
 function esc(value) {
   return String(value).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
@@ -87,7 +93,7 @@ const prerenderHtml = `
       <div style="text-transform:uppercase;letter-spacing:0.2em;font-size:12px;color:#22d3ee;">Pricing</div>
       <h2 style="color:#fff;font-size:24px;margin-top:8px;">Upgrade only when the product earns the click.</h2>
       <ul style="margin-top:12px;padding-left:18px;line-height:1.7;color:#cbd5e1;">
-        ${pricing.map(([name, price, body]) => `<li><strong style="color:#fff;">${esc(name)} — ${esc(price)}:</strong> ${esc(body)}</li>`).join("\n        ")}
+        ${pricingRows.map(([name, price, body]) => `<li><strong style="color:#fff;">${esc(name)} — ${esc(price)}:</strong> ${esc(body)}</li>`).join("\n        ")}
       </ul>
     </section>
   </main>
@@ -98,13 +104,56 @@ const prerenderHtml = `
 
 const ROOT_EMPTY = '<div id="root"></div>';
 
+// Rewrite the WebApplication JSON-LD `offers` array from pricing.json. index.html
+// is hand-maintained, so this makes the shipped structured data authoritative
+// even if someone edits a price there and forgets the JSON.
+function syncStructuredDataOffers(html) {
+  const offers = pricing.plans.map((plan) => ({
+    "@type": "Offer",
+    name: plan.name,
+    price: String(plan.price),
+    priceCurrency: pricing.currency,
+  }));
+
+  const scriptPattern = /<script type="application\/ld\+json">\s*([\s\S]*?)\s*<\/script>/;
+  const match = html.match(scriptPattern);
+  if (!match) {
+    console.warn("[prerender] No JSON-LD block found; leaving structured data untouched.");
+    return html;
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(match[1]);
+  } catch {
+    console.warn("[prerender] JSON-LD block is not valid JSON; leaving structured data untouched.");
+    return html;
+  }
+
+  if (parsed["@type"] !== "WebApplication") return html;
+
+  parsed.offers = offers;
+  const serialized = JSON.stringify(parsed, null, 2)
+    .split("\n")
+    .map((line, index) => (index === 0 ? line : `      ${line}`))
+    .join("\n");
+
+  // Function replacer: the payload contains `$` (prices), which a string
+  // replacement would treat as a capture-group escape.
+  return html.replace(
+    scriptPattern,
+    () => `<script type="application/ld+json">\n      ${serialized}\n    </script>`,
+  );
+}
+
 try {
   const html = await readFile(indexPath, "utf8");
   if (!html.includes(ROOT_EMPTY)) {
     console.warn("[prerender] '<div id=\"root\"></div>' not found in dist/index.html; skipping injection.");
     process.exit(0);
   }
-  const next = html.replace(ROOT_EMPTY, `<div id="root">${prerenderHtml}</div>`);
+  let next = html.replace(ROOT_EMPTY, () => `<div id="root">${prerenderHtml}</div>`);
+  next = syncStructuredDataOffers(next);
   await writeFile(indexPath, next);
   console.log("[prerender] Injected static homepage marketing content into dist/index.html");
 } catch (error) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { Suspense, lazy, useEffect, useState } from "react";
-import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import Index from "./pages/Index";
@@ -12,6 +12,7 @@ const Leaderboard = lazy(() => import("./pages/Leaderboard"));
 const Profile = lazy(() => import("./pages/Profile"));
 const Login = lazy(() => import("./pages/Login"));
 const Signup = lazy(() => import("./pages/Signup"));
+const NotFound = lazy(() => import("./pages/NotFound"));
 
 function RouteFallback() {
   return (
@@ -91,7 +92,7 @@ function App() {
             <Route path="/profile" element={<Profile />} />
             <Route path="/login" element={<Login />} />
             <Route path="/signup" element={<Signup />} />
-            <Route path="*" element={<Navigate to="/" replace />} />
+            <Route path="*" element={<NotFound />} />
           </Routes>
         </Suspense>
       </BrowserRouter>

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -1,0 +1,141 @@
+import { useState } from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { Link } from "react-router-dom";
+import { ChevronRight, Menu, UserCircle2, Wallet, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { SiteUser } from "@/lib/auth";
+
+export interface MobileNavLink {
+  label: string;
+  href: string;
+}
+
+interface MobileNavProps {
+  links: MobileNavLink[];
+  siteUser: SiteUser | null;
+  hasPaidAccess: boolean;
+  onOpenDesk: () => void;
+  onRestoreAccess: () => void;
+}
+
+/**
+ * Below `lg` the desk header collapsed to just the logo and the "Open desk" CTA —
+ * the section links, "Log in", "Account", and "Restore" were all hidden behind
+ * `sm:`/`lg:`/`xl:` breakpoints with nothing standing in for them. On a phone there
+ * was no way to sign in or reach a profile at all. This is that missing surface.
+ *
+ * Built on Radix Dialog for the focus trap, Escape handling, and scroll lock.
+ */
+export default function MobileNav({
+  links,
+  siteUser,
+  hasPaidAccess,
+  onOpenDesk,
+  onRestoreAccess,
+}: MobileNavProps) {
+  const [open, setOpen] = useState(false);
+  const close = () => setOpen(false);
+
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={setOpen}>
+      <DialogPrimitive.Trigger asChild>
+        <button
+          type="button"
+          aria-label="Open menu"
+          className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-white/10 bg-white/[0.03] text-slate-300 transition-colors hover:bg-white/[0.07] hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#b9ff55]/70 lg:hidden"
+        >
+          <Menu className="h-4 w-4" aria-hidden="true" />
+        </button>
+      </DialogPrimitive.Trigger>
+
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="fixed inset-0 z-40 bg-black/70 backdrop-blur-sm data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0 lg:hidden" />
+        <DialogPrimitive.Content className="fixed inset-x-0 top-0 z-50 max-h-[100dvh] overflow-y-auto border-b border-white/10 bg-[#05070d] px-4 pb-6 pt-4 shadow-[0_30px_100px_rgba(0,0,0,0.6)] duration-200 data-[state=closed]:animate-out data-[state=closed]:slide-out-to-top data-[state=open]:animate-in data-[state=open]:slide-in-from-top sm:px-6 lg:hidden">
+          <DialogPrimitive.Title className="sr-only">Site navigation</DialogPrimitive.Title>
+          <DialogPrimitive.Description className="sr-only">
+            Jump to a section, manage your account, or open the desk.
+          </DialogPrimitive.Description>
+
+          <div className="flex items-center justify-between gap-4">
+            <div className="text-[10px] font-semibold uppercase tracking-[0.2em] text-slate-500">Menu</div>
+            <DialogPrimitive.Close asChild>
+              <button
+                type="button"
+                aria-label="Close menu"
+                className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-white/10 bg-white/[0.03] text-slate-300 transition-colors hover:bg-white/[0.07] hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#b9ff55]/70"
+              >
+                <X className="h-4 w-4" aria-hidden="true" />
+              </button>
+            </DialogPrimitive.Close>
+          </div>
+
+          <nav aria-label="Primary" className="mt-4 grid gap-1">
+            {links.map((link) => (
+              <a
+                key={link.href}
+                href={link.href}
+                onClick={close}
+                className="rounded-lg px-3 py-3 text-sm font-medium text-slate-300 transition-colors hover:bg-white/[0.05] hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#b9ff55]/70"
+              >
+                {link.label}
+              </a>
+            ))}
+          </nav>
+
+          <div className="mt-4 grid gap-2 border-t border-white/10 pt-4">
+            <Button
+              asChild
+              variant="ghost"
+              className="justify-start text-sm text-slate-300 hover:bg-white/[0.05] hover:text-white"
+              onClick={close}
+            >
+              {siteUser ? (
+                <Link to="/profile">
+                  <UserCircle2 className="mr-2 h-4 w-4" aria-hidden="true" />
+                  Account
+                </Link>
+              ) : (
+                <Link to="/login">
+                  <UserCircle2 className="mr-2 h-4 w-4" aria-hidden="true" />
+                  Log in
+                </Link>
+              )}
+            </Button>
+
+            <Button
+              variant="ghost"
+              className="justify-start text-sm text-slate-300 hover:bg-white/[0.05] hover:text-white"
+              onClick={() => {
+                close();
+                onRestoreAccess();
+              }}
+            >
+              <Wallet className="mr-2 h-4 w-4" aria-hidden="true" />
+              Restore access
+            </Button>
+
+            {hasPaidAccess ? (
+              <Button asChild className="mt-1 bg-[#b9ff55] font-semibold text-[#0b1007] hover:bg-[#d0ff8e]" onClick={close}>
+                <Link to="/daily-picks">
+                  Open desk
+                  <ChevronRight className="ml-1 h-4 w-4" aria-hidden="true" />
+                </Link>
+              </Button>
+            ) : (
+              <Button
+                className="mt-1 bg-[#b9ff55] font-semibold text-[#0b1007] hover:bg-[#d0ff8e]"
+                onClick={() => {
+                  close();
+                  onOpenDesk();
+                }}
+              >
+                Open desk
+                <ChevronRight className="ml-1 h-4 w-4" aria-hidden="true" />
+              </Button>
+            )}
+          </div>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}

--- a/src/components/PaymentOptionDialog.tsx
+++ b/src/components/PaymentOptionDialog.tsx
@@ -1,6 +1,10 @@
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { CreditCard, Coins, ShieldCheck, Flame } from "lucide-react";
+import { formatPlanPrice, getPlan, TRIAL_DAYS } from "@/lib/pricing";
+
+const premiumPlan = getPlan("premium");
+const eventPlan = getPlan("one-time");
 
 interface PaymentOptionDialogProps {
   open: boolean;
@@ -42,14 +46,14 @@ export default function PaymentOptionDialog({
                 <CreditCard className="h-5 w-5" />
               </div>
               <div>
-                <div className="text-sm font-semibold">Start 7-day Pro trial</div>
-                <div className="text-xs font-normal text-zinc-400">Then $15/mo — cancel in the portal anytime</div>
+                <div className="text-sm font-semibold">Start {TRIAL_DAYS}-day Pro trial</div>
+                <div className="text-xs font-normal text-zinc-400">Then {formatPlanPrice(premiumPlan)}/mo — cancel in the portal anytime</div>
               </div>
             </Button>
           ) : null}
 
           <div className="flex items-center justify-center gap-2 rounded-2xl border border-white/5 bg-white/[0.02] p-4 text-center">
-            <div className="text-3xl font-extrabold text-white">$10</div>
+            <div className="text-3xl font-extrabold text-white">{formatPlanPrice(eventPlan)}</div>
             <div className="text-xs text-zinc-400">One-time / 72-hour pass</div>
           </div>
 
@@ -63,7 +67,7 @@ export default function PaymentOptionDialog({
               </div>
               <div>
                 <div className="text-sm font-semibold">Event pass with card</div>
-                <div className="text-xs font-normal text-zinc-400">Secure Stripe checkout · $10</div>
+                <div className="text-xs font-normal text-zinc-400">Secure Stripe checkout · {formatPlanPrice(eventPlan)}</div>
               </div>
             </Button>
 

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -3,10 +3,23 @@ import * as SliderPrimitive from "@radix-ui/react-slider"
 
 import { cn } from "@/lib/utils"
 
+type SliderProps = React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root> & {
+  /**
+   * Announced instead of the raw number, e.g. "25%" for a 0.25 Kelly fraction
+   * or "$1,000" for a bankroll.
+   */
+  valueText?: string
+}
+
+/**
+ * `aria-label` lands on the thumb, not the root: the thumb is the element Radix
+ * gives `role="slider"`, so a label on the root leaves the control unnamed for
+ * screen readers. Callers pass `aria-label` as usual and it is routed for them.
+ */
 const Slider = React.forwardRef<
   React.ElementRef<typeof SliderPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
->(({ className, ...props }, ref) => (
+  SliderProps
+>(({ className, valueText, "aria-label": ariaLabel, "aria-labelledby": ariaLabelledBy, ...props }, ref) => (
   <SliderPrimitive.Root
     ref={ref}
     className={cn(
@@ -18,7 +31,12 @@ const Slider = React.forwardRef<
     <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary">
       <SliderPrimitive.Range className="absolute h-full bg-primary" />
     </SliderPrimitive.Track>
-    <SliderPrimitive.Thumb className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />
+    <SliderPrimitive.Thumb
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
+      aria-valuetext={valueText}
+      className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
+    />
   </SliderPrimitive.Root>
 ))
 Slider.displayName = SliderPrimitive.Root.displayName

--- a/src/data/pricing.json
+++ b/src/data/pricing.json
@@ -1,0 +1,30 @@
+{
+  "currency": "USD",
+  "trialDays": 7,
+  "plans": [
+    {
+      "id": "free",
+      "name": "Free Desk",
+      "price": 0,
+      "cadence": "forever",
+      "badge": "Open",
+      "seoBlurb": "Live board, model leans, and the public proof ledger."
+    },
+    {
+      "id": "premium",
+      "name": "Pro Monthly",
+      "price": 15,
+      "cadence": "per month after 7-day free trial",
+      "badge": "Best fit",
+      "seoBlurb": "Deeper boards, historical ledgers, and workflow tools."
+    },
+    {
+      "id": "one-time",
+      "name": "Event Pass",
+      "price": 10,
+      "cadence": "One-time card or crypto unlock",
+      "badge": "72 hours",
+      "seoBlurb": "Unlock the full execution board for a single slate."
+    }
+  ]
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,3 +1,7 @@
+// Type-only: erased at compile time, so this does not reintroduce the runtime
+// auth.ts -> stripe.ts edge that moving signOutAccessSession here removed.
+import type { AccessState } from "@/lib/stripe";
+
 export interface SiteUser {
   id: string;
   email: string;

--- a/src/lib/pricing.test.ts
+++ b/src/lib/pricing.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { getPlan, PLANS, TRIAL_DAYS } from "./pricing";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+describe("pricing source of truth", () => {
+  it("exposes the three advertised plans", () => {
+    expect(PLANS.map((plan) => plan.id)).toEqual(["free", "premium", "one-time"]);
+  });
+
+  it("keeps the free tier free", () => {
+    expect(getPlan("free").price).toBe(0);
+  });
+
+  // Regression guard: index.html once advertised Pro Monthly at $19 in JSON-LD
+  // while checkout charged $15. Google surfaced the stale number in rich results.
+  it("matches the prices in the index.html JSON-LD offers", () => {
+    const html = readFileSync(join(repoRoot, "index.html"), "utf8");
+    const match = html.match(/<script type="application\/ld\+json">\s*([\s\S]*?)\s*<\/script>/);
+    expect(match, "index.html should contain a JSON-LD block").toBeTruthy();
+
+    const structuredData = JSON.parse(match![1]);
+    const offersByName = new Map<string, string>(
+      structuredData.offers.map((offer: { name: string; price: string }) => [offer.name, offer.price]),
+    );
+
+    for (const plan of PLANS) {
+      expect(offersByName.get(plan.name), `JSON-LD offer for "${plan.name}"`).toBe(String(plan.price));
+    }
+  });
+
+  it("advertises a trial length the checkout copy can reuse", () => {
+    expect(TRIAL_DAYS).toBeGreaterThan(0);
+    expect(getPlan("premium").cadence).toContain(`${TRIAL_DAYS}-day`);
+  });
+});

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -1,0 +1,34 @@
+// Single source of truth for advertised prices.
+//
+// These numbers used to be retyped in three places — the pricing cards here, the
+// WebApplication JSON-LD in index.html, and the prerendered marketing block in
+// scripts/prerender.mjs. They drifted: crawlers and no-JS viewers were told Pro
+// Monthly cost $19 while checkout charged $15. Everything now reads pricing.json,
+// and pricing.test.ts fails the build if a copy falls out of sync again.
+import pricingData from "@/data/pricing.json";
+
+export type PlanId = "free" | "premium" | "one-time";
+
+export interface Plan {
+  id: PlanId;
+  name: string;
+  price: number;
+  cadence: string;
+  badge: string;
+  seoBlurb: string;
+}
+
+export const CURRENCY: string = pricingData.currency;
+export const TRIAL_DAYS: number = pricingData.trialDays;
+export const PLANS = pricingData.plans as Plan[];
+
+export function getPlan(id: PlanId): Plan {
+  const plan = PLANS.find((candidate) => candidate.id === id);
+  if (!plan) throw new Error(`Unknown plan: ${id}`);
+  return plan;
+}
+
+/** Whole-dollar display price, e.g. `$15`. Prices are advertised in round dollars. */
+export function formatPlanPrice(plan: Plan): string {
+  return `$${plan.price}`;
+}

--- a/src/lib/useDocumentMeta.ts
+++ b/src/lib/useDocumentMeta.ts
@@ -1,0 +1,84 @@
+import { useEffect } from "react";
+
+/**
+ * Per-route document metadata for a client-rendered SPA.
+ *
+ * Every route used to inherit the static tags in index.html verbatim: one
+ * `<title>`, one description, and `<link rel="canonical" href="https://aiadvantagesports.com/">`.
+ * That last one is the damaging part — sitemap.xml submits /daily-picks,
+ * /leaderboard, /login, and /signup for indexing, while each of those pages
+ * told crawlers it was a duplicate of the homepage. The sitemap and the pages
+ * were arguing, and the canonical wins.
+ *
+ * Netlify serves the SPA fallback, so this is set client-side after hydration
+ * rather than in the served HTML. Crawlers that execute JS pick it up; a
+ * server-rendered or per-route prerendered head would be strictly better and is
+ * the natural follow-up if these routes matter for organic traffic.
+ */
+
+export const SITE_ORIGIN = "https://aiadvantagesports.com";
+
+export interface DocumentMeta {
+  title: string;
+  description?: string;
+  /** Route path such as "/daily-picks". Resolved against SITE_ORIGIN. */
+  canonicalPath?: string;
+  /** e.g. "noindex,follow" for pages that should stay out of the index. */
+  robots?: string;
+}
+
+function upsertMeta(name: string, content: string): void {
+  let tag = document.head.querySelector<HTMLMetaElement>(`meta[name="${name}"]`);
+  if (!tag) {
+    tag = document.createElement("meta");
+    tag.name = name;
+    document.head.appendChild(tag);
+  }
+  tag.content = content;
+}
+
+function upsertCanonical(href: string): void {
+  let link = document.head.querySelector<HTMLLinkElement>('link[rel="canonical"]');
+  if (!link) {
+    link = document.createElement("link");
+    link.rel = "canonical";
+    document.head.appendChild(link);
+  }
+  link.href = href;
+}
+
+// Captured once, before any route has overwritten them, so unmount restores the
+// index.html values rather than whatever the previously mounted route set. A
+// route that forgets to call this hook then inherits the site defaults instead
+// of a stale neighbour's title.
+const defaults = {
+  title: typeof document === "undefined" ? "" : document.title,
+  description:
+    typeof document === "undefined"
+      ? ""
+      : (document.head.querySelector<HTMLMetaElement>('meta[name="description"]')?.content ?? ""),
+  canonical:
+    typeof document === "undefined"
+      ? `${SITE_ORIGIN}/`
+      : (document.head.querySelector<HTMLLinkElement>('link[rel="canonical"]')?.href ?? `${SITE_ORIGIN}/`),
+  robots:
+    typeof document === "undefined"
+      ? "index,follow"
+      : (document.head.querySelector<HTMLMetaElement>('meta[name="robots"]')?.content ?? "index,follow"),
+};
+
+export function useDocumentMeta({ title, description, canonicalPath, robots }: DocumentMeta): void {
+  useEffect(() => {
+    document.title = title;
+    if (description) upsertMeta("description", description);
+    if (canonicalPath) upsertCanonical(`${SITE_ORIGIN}${canonicalPath}`);
+    if (robots) upsertMeta("robots", robots);
+
+    return () => {
+      document.title = defaults.title;
+      if (description) upsertMeta("description", defaults.description);
+      if (canonicalPath) upsertCanonical(defaults.canonical);
+      if (robots) upsertMeta("robots", defaults.robots);
+    };
+  }, [title, description, canonicalPath, robots]);
+}

--- a/src/pages/DailyPicks.tsx
+++ b/src/pages/DailyPicks.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState, useRef } from "react";
+import { useDocumentMeta } from "@/lib/useDocumentMeta";
 import { Link } from "react-router-dom";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -640,6 +641,13 @@ function PickCard({
 }
 
 export default function DailyPicks() {
+  useDocumentMeta({
+    title: "Daily Picks — AI Advantage Sports",
+    description:
+      "The full execution board: every qualified play with model probability, execution-adjusted edge, recommended stake, and entry window.",
+    canonicalPath: "/daily-picks",
+  });
+
   const [access, setAccess] = useState(getAccessState());
   const [cryptoAccount, setCryptoAccount] = useState(getCurrentCryptoAccount());
   const [siteUser, setSiteUser] = useState<SiteUser | null>(getCurrentSiteUser());
@@ -893,6 +901,8 @@ export default function DailyPicks() {
               </div>
               <Slider
                 className="mt-3"
+                aria-label="Minimum execution edge"
+                valueText={`${minExecEdge.toFixed(0)}%`}
                 min={0}
                 max={12}
                 step={1}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -61,13 +61,26 @@ import {
   signOutAccessSession,
   type BillingStatus,
 } from "@/lib/stripe";
+import { formatPlanPrice, getPlan, TRIAL_DAYS } from "@/lib/pricing";
 import CryptoPaymentModal, { type UnlockType } from "@/components/CryptoPaymentModal";
 import AccessSessionDialog from "@/components/AccessSessionDialog";
 import SubstackEmbed from "@/components/SubstackEmbed";
+import MobileNav from "@/components/MobileNav";
 import { createExecutionBoardEntry } from "@/lib/executionBoard";
 const BacktestChart = lazy(() => import("@/components/BacktestChart"));
 
 const ETH_DONATION_ADDRESS = "0x6f278ce76ba5ed31fd9be646d074863e126836e9";
+
+const NAV_LINKS = [
+  { label: "Live desk", href: "#live-desk" },
+  { label: "Proof ledger", href: "#proof" },
+  { label: "Model lab", href: "#model-lab" },
+  { label: "Pricing", href: "#pricing" },
+];
+
+const freePlan = getPlan("free");
+const premiumPlan = getPlan("premium");
+const eventPlan = getPlan("one-time");
 
 const productProof = [
   {
@@ -579,19 +592,20 @@ Bet responsibly. This is model output, not a guarantee.`);
             </div>
           </Link>
 
-          <nav className="hidden items-center gap-7 text-xs font-medium text-slate-400 lg:flex">
-            <a href="#live-desk" className="text-[#b9ff55] transition-colors hover:text-[#d7ff9a]">
-              Live desk
-            </a>
-            <a href="#proof" className="transition-colors hover:text-white">
-              Proof ledger
-            </a>
-            <a href="#model-lab" className="transition-colors hover:text-white">
-              Model lab
-            </a>
-            <a href="#pricing" className="transition-colors hover:text-white">
-              Pricing
-            </a>
+          <nav aria-label="Primary" className="hidden items-center gap-7 text-xs font-medium text-slate-400 lg:flex">
+            {NAV_LINKS.map((link, index) => (
+              <a
+                key={link.href}
+                href={link.href}
+                className={
+                  index === 0
+                    ? "text-[#b9ff55] transition-colors hover:text-[#d7ff9a]"
+                    : "transition-colors hover:text-white"
+                }
+              >
+                {link.label}
+              </a>
+            ))}
           </nav>
 
           <div className="flex items-center gap-2">
@@ -647,6 +661,13 @@ Bet responsibly. This is model output, not a guarantee.`);
                 <ChevronRight className="ml-1 h-3.5 w-3.5" />
               </Button>
             )}
+            <MobileNav
+              links={NAV_LINKS}
+              siteUser={siteUser}
+              hasPaidAccess={hasPaidAccess}
+              onOpenDesk={() => void handleUpgrade("premium")}
+              onRestoreAccess={() => setShowAccessDialog(true)}
+            />
           </div>
         </div>
       </header>
@@ -754,11 +775,16 @@ Bet responsibly. This is model output, not a guarantee.`);
                         Model, market, edge, and stake in one decision row.
                       </p>
                     </div>
-                    <div className="flex flex-wrap items-center gap-1 rounded-lg border border-white/10 bg-white/[0.025] p-1">
+                    <div
+                      role="group"
+                      aria-label="Sport"
+                      className="flex flex-wrap items-center gap-1 rounded-lg border border-white/10 bg-white/[0.025] p-1"
+                    >
                       {LIVE_DESK_SPORTS.map((sport) => (
                         <button
                           key={sport}
                           type="button"
+                          aria-pressed={selectedSport === sport}
                           className={`rounded-md px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.1em] transition-colors ${
                             selectedSport === sport
                               ? "bg-[#b9ff55] text-[#0b1007]"
@@ -831,7 +857,13 @@ Bet responsibly. This is model output, not a guarantee.`);
                     </table>
                   </div>
 
-                  <div className="flex items-center justify-between border-t border-white/10 px-5 py-3 text-[10px] uppercase tracking-[0.12em] text-slate-600">
+                  {/* The board repolls every 60s. Announcing the table itself would
+                      be relentless, so this compact status line carries the update. */}
+                  <div
+                    role="status"
+                    aria-live="polite"
+                    className="flex items-center justify-between border-t border-white/10 px-5 py-3 text-[10px] uppercase tracking-[0.12em] text-slate-600"
+                  >
                     <span>{postedLineCount} posted lines · {liveCount} live</span>
                     <span>{liveSlateUpdatedAt ? `Sync ${liveSlateUpdatedAt.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })}` : "Syncing"}</span>
                   </div>
@@ -858,6 +890,8 @@ Bet responsibly. This is model output, not a guarantee.`);
                       </div>
                       <Slider
                         className="[&_[role=slider]]:border-[#b9ff55] [&_[role=slider]]:bg-[#05070d] [&_[data-orientation=horizontal]>span]:bg-[#b9ff55]"
+                        aria-label="Bankroll"
+                        valueText={formatMoney(bankroll)}
                         value={[bankroll]}
                         onValueChange={(v) => setBankroll(v[0])}
                         min={100}
@@ -875,7 +909,15 @@ Bet responsibly. This is model output, not a guarantee.`);
                         <span className="text-xs text-slate-500">Minimum edge</span>
                         <span className="font-mono text-lg font-semibold tabular-nums text-cyan-200">{minEdge}%</span>
                       </div>
-                      <Slider value={[minEdge]} onValueChange={(v) => setMinEdge(v[0])} min={0} max={10} step={0.5} />
+                      <Slider
+                        aria-label="Minimum edge"
+                        valueText={`${minEdge}%`}
+                        value={[minEdge]}
+                        onValueChange={(v) => setMinEdge(v[0])}
+                        min={0}
+                        max={10}
+                        step={0.5}
+                      />
                     </div>
 
                     <div>
@@ -886,6 +928,8 @@ Bet responsibly. This is model output, not a guarantee.`);
                         </span>
                       </div>
                       <Slider
+                        aria-label="Kelly fraction"
+                        valueText={`${(kellyFraction * 100).toFixed(0)}%`}
                         value={[kellyFraction]}
                         onValueChange={(v) => setKellyFraction(v[0])}
                         min={0.1}
@@ -984,13 +1028,14 @@ Bet responsibly. This is model output, not a guarantee.`);
                 title="A usable slate, not a wall of hype."
                 description="Pick a sport, inspect current games, and only act when the model and the execution filters agree."
               />
-              <div className="flex rounded-lg border border-white/10 bg-white/[0.035] p-1">
+              <div role="group" aria-label="Sport" className="flex rounded-lg border border-white/10 bg-white/[0.035] p-1">
                 {LIVE_DESK_SPORTS.map((sport) => (
                   <Button
                     key={sport}
                     type="button"
                     size="sm"
                     variant="ghost"
+                    aria-pressed={selectedSport === sport}
                     className={
                       selectedSport === sport
                         ? "bg-cyan-300 text-slate-950 hover:bg-cyan-200"
@@ -1051,10 +1096,26 @@ Bet responsibly. This is model output, not a guarantee.`);
                               <div className="flex items-center gap-3">
                                 <div className="flex -space-x-2">
                                   {game.awayLogo ? (
-                                    <img src={game.awayLogo} alt="" className="h-8 w-8 rounded-full bg-white p-1" />
+                                    <img
+                                      src={game.awayLogo}
+                                      alt=""
+                                      width={32}
+                                      height={32}
+                                      loading="lazy"
+                                      decoding="async"
+                                      className="h-8 w-8 rounded-full bg-white p-1"
+                                    />
                                   ) : null}
                                   {game.homeLogo ? (
-                                    <img src={game.homeLogo} alt="" className="h-8 w-8 rounded-full bg-white p-1" />
+                                    <img
+                                      src={game.homeLogo}
+                                      alt=""
+                                      width={32}
+                                      height={32}
+                                      loading="lazy"
+                                      decoding="async"
+                                      className="h-8 w-8 rounded-full bg-white p-1"
+                                    />
                                   ) : null}
                                 </div>
                                 <div>
@@ -1160,7 +1221,15 @@ Bet responsibly. This is model output, not a guarantee.`);
                         </span>
                         <span className="font-semibold text-white">{formatMoney(bankroll)}</span>
                       </div>
-                      <Slider value={[bankroll]} onValueChange={(v) => setBankroll(v[0])} min={100} max={10000} step={100} />
+                      <Slider
+                        aria-label="Bankroll"
+                        valueText={formatMoney(bankroll)}
+                        value={[bankroll]}
+                        onValueChange={(v) => setBankroll(v[0])}
+                        min={100}
+                        max={10000}
+                        step={100}
+                      />
                     </div>
                     <div>
                       <div className="mb-3 flex items-center justify-between text-sm">
@@ -1169,7 +1238,15 @@ Bet responsibly. This is model output, not a guarantee.`);
                         </span>
                         <span className="font-semibold text-white">{minEdge}%</span>
                       </div>
-                      <Slider value={[minEdge]} onValueChange={(v) => setMinEdge(v[0])} min={0} max={10} step={0.5} />
+                      <Slider
+                        aria-label="Minimum edge"
+                        valueText={`${minEdge}%`}
+                        value={[minEdge]}
+                        onValueChange={(v) => setMinEdge(v[0])}
+                        min={0}
+                        max={10}
+                        step={0.5}
+                      />
                     </div>
                     <div>
                       <div className="mb-3 flex items-center justify-between text-sm">
@@ -1178,7 +1255,15 @@ Bet responsibly. This is model output, not a guarantee.`);
                         </span>
                         <span className="font-semibold text-white">{(kellyFraction * 100).toFixed(0)}%</span>
                       </div>
-                      <Slider value={[kellyFraction]} onValueChange={(v) => setKellyFraction(v[0])} min={0.1} max={1} step={0.05} />
+                      <Slider
+                        aria-label="Kelly fraction"
+                        valueText={`${(kellyFraction * 100).toFixed(0)}%`}
+                        value={[kellyFraction]}
+                        onValueChange={(v) => setKellyFraction(v[0])}
+                        min={0.1}
+                        max={1}
+                        step={0.05}
+                      />
                     </div>
                   </div>
                 </div>
@@ -1505,10 +1590,10 @@ The report will show:
             <div className="mt-8 grid gap-5 lg:grid-cols-3">
               <div className="rounded-xl border border-white/10 bg-white/[0.035] p-6 transition-all duration-300 hover:-translate-y-1 hover:border-slate-500/40 hover:bg-white/[0.05]">
                 <div className="flex items-center justify-between">
-                  <h3 className="text-2xl font-semibold text-white">Free Desk</h3>
-                  <Badge className="border-white/10 bg-white/[0.05] text-slate-300">Open</Badge>
+                  <h3 className="text-2xl font-semibold text-white">{freePlan.name}</h3>
+                  <Badge className="border-white/10 bg-white/[0.05] text-slate-300">{freePlan.badge}</Badge>
                 </div>
-                <div className="mt-6 text-4xl font-semibold text-white">$0</div>
+                <div className="mt-6 text-4xl font-semibold text-white">{formatPlanPrice(freePlan)}</div>
                 <ul className="mt-6 space-y-3">
                   {FREE_FEATURES.map((feature) => (
                     <li key={feature} className="flex gap-3 text-sm leading-6 text-slate-400">
@@ -1524,11 +1609,11 @@ The report will show:
 
               <div className="rounded-xl border border-cyan-300/25 bg-cyan-300/[0.06] p-6 shadow-[0_24px_80px_rgba(34,211,238,0.08)] transition-all duration-300 hover:-translate-y-1 hover:border-cyan-300/40 hover:shadow-[0_32px_96px_rgba(34,211,238,0.16)]">
                 <div className="flex items-center justify-between">
-                  <h3 className="text-2xl font-semibold text-white">Pro Monthly</h3>
-                  <Badge className="border-cyan-300/30 bg-cyan-300/10 text-cyan-100">Best fit</Badge>
+                  <h3 className="text-2xl font-semibold text-white">{premiumPlan.name}</h3>
+                  <Badge className="border-cyan-300/30 bg-cyan-300/10 text-cyan-100">{premiumPlan.badge}</Badge>
                 </div>
-                <div className="mt-6 text-4xl font-semibold text-white">$15</div>
-                <div className="mt-2 text-sm text-slate-400">per month after 7-day free trial</div>
+                <div className="mt-6 text-4xl font-semibold text-white">{formatPlanPrice(premiumPlan)}</div>
+                <div className="mt-2 text-sm text-slate-400">{premiumPlan.cadence}</div>
                 <ul className="mt-6 space-y-3">
                   {PREMIUM_FEATURES.slice(0, 5).map((feature) => (
                     <li key={feature} className="flex gap-3 text-sm leading-6 text-slate-300">
@@ -1539,17 +1624,17 @@ The report will show:
                 </ul>
                 <Button className="mt-8 w-full bg-cyan-300 text-slate-950 hover:bg-cyan-200" onClick={() => void handleUpgrade("premium")}>
                   <Crown className="mr-2 h-4 w-4" />
-                  Start 7-day trial
+                  Start {TRIAL_DAYS}-day trial
                 </Button>
               </div>
 
               <div className="rounded-xl border border-amber-300/20 bg-amber-300/[0.055] p-6 transition-all duration-300 hover:-translate-y-1 hover:border-amber-300/45 hover:bg-amber-300/[0.075]">
                 <div className="flex items-center justify-between">
-                  <h3 className="text-2xl font-semibold text-white">Event Pass</h3>
-                  <Badge className="border-amber-300/30 bg-amber-300/10 text-amber-100">72 hours</Badge>
+                  <h3 className="text-2xl font-semibold text-white">{eventPlan.name}</h3>
+                  <Badge className="border-amber-300/30 bg-amber-300/10 text-amber-100">{eventPlan.badge}</Badge>
                 </div>
-                <div className="mt-6 text-4xl font-semibold text-white">$10</div>
-                <div className="mt-2 text-sm text-slate-400">One-time card or crypto unlock</div>
+                <div className="mt-6 text-4xl font-semibold text-white">{formatPlanPrice(eventPlan)}</div>
+                <div className="mt-2 text-sm text-slate-400">{eventPlan.cadence}</div>
                 <ul className="mt-6 space-y-3">
                   {PREMIUM_FEATURES.slice(0, 4).map((feature) => (
                     <li key={feature} className="flex gap-3 text-sm leading-6 text-slate-300">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense, useEffect, useMemo, useState } from "react";
+import { useDocumentMeta } from "@/lib/useDocumentMeta";
 import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -284,6 +285,13 @@ function formatMarketAudit(game: LiveMarketGame) {
 }
 
 function Index() {
+  useDocumentMeta({
+    title: "AI Advantage Sports — Live Lines, Model Edge, Kelly Sizing",
+    description:
+      "Execution-first sports betting intelligence: live lines, model probabilities, execution-adjusted edge, and quarter-Kelly stake guidance for NBA, NFL, MLB, and the World Cup.",
+    canonicalPath: "/",
+  });
+
   const [gameInput, setGameInput] = useState("");
   const [bettingAdvice, setBettingAdvice] = useState("");
   const [isLoading, setIsLoading] = useState(false);

--- a/src/pages/Leaderboard.tsx
+++ b/src/pages/Leaderboard.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { useDocumentMeta } from "@/lib/useDocumentMeta";
 import { Link } from "react-router-dom";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -128,6 +129,13 @@ function HistoryTable({ rows }: { rows: HistoricalExecutionLedgerEntry[] }) {
 }
 
 export default function Leaderboard() {
+  useDocumentMeta({
+    title: "Proof Ledger — AI Advantage Sports",
+    description:
+      "The public settled record: graded picks, closing-line value, and calibration history for every recommendation the desk has made.",
+    canonicalPath: "/leaderboard",
+  });
+
   const [access, setAccess] = useState(getAccessState());
   const [games, setGames] = useState<LiveMarketGame[]>([]);
   const [isLoading, setIsLoading] = useState(true);

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, type FormEvent } from "react";
+import { useDocumentMeta } from "@/lib/useDocumentMeta";
 import { Link, useNavigate } from "react-router-dom";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -10,6 +11,12 @@ import { KeyRound, LockOpen, UserCircle2 } from "lucide-react";
 import BrandedHeader from "@/components/BrandedHeader";
 
 export default function Login() {
+  useDocumentMeta({
+    title: "Log In — AI Advantage Sports",
+    description: "Log in to AI Advantage Sports to reach your execution desk and proof ledger.",
+    canonicalPath: "/login",
+  });
+
   const navigate = useNavigate();
   const { toast } = useToast();
   const [login, setLogin] = useState("");

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,7 +1,7 @@
-import { useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { ArrowLeft, Compass } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { useDocumentMeta } from "@/lib/useDocumentMeta";
 
 const SUGGESTIONS = [
   { to: "/", label: "Live desk", detail: "Current slate, model edge, and Kelly sizing" },
@@ -17,30 +17,12 @@ const SUGGESTIONS = [
 export default function NotFound() {
   const location = useLocation();
 
-  useEffect(() => {
-    // The SPA fallback serves this at a 200, so the status code can't say
-    // "gone". A robots meta tag is what actually keeps bad URLs out of the index.
-    //
-    // index.html ships a static `robots: index,follow`. Appending a second meta
-    // leaves that permissive one first in the document, so retarget the existing
-    // tag and restore it on unmount rather than adding a competing one.
-    const existing = document.head.querySelector<HTMLMetaElement>('meta[name="robots"]');
-    const meta = existing ?? document.createElement("meta");
-    const previousContent = existing?.content ?? null;
-
-    meta.name = "robots";
-    meta.content = "noindex,follow";
-    if (!existing) document.head.appendChild(meta);
-
-    const previousTitle = document.title;
-    document.title = "Page not found — AI Advantage Sports";
-
-    return () => {
-      if (previousContent === null) meta.remove();
-      else meta.content = previousContent;
-      document.title = previousTitle;
-    };
-  }, []);
+  // The SPA fallback serves this at a 200, so the status code can't say "gone".
+  // The robots tag is what actually keeps mistyped URLs out of the index.
+  useDocumentMeta({
+    title: "Page not found — AI Advantage Sports",
+    robots: "noindex,follow",
+  });
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-[#05070d] px-5 py-16 text-slate-100">

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,0 +1,95 @@
+import { useEffect } from "react";
+import { Link, useLocation } from "react-router-dom";
+import { ArrowLeft, Compass } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+const SUGGESTIONS = [
+  { to: "/", label: "Live desk", detail: "Current slate, model edge, and Kelly sizing" },
+  { to: "/daily-picks", label: "Daily picks", detail: "The full execution board" },
+  { to: "/leaderboard", label: "Proof ledger", detail: "Settled results and CLV history" },
+];
+
+/**
+ * Unknown routes used to `<Navigate to="/" replace />`, which hands crawlers a
+ * 200-with-homepage-content for every bad URL — a soft 404 — and silently
+ * teleports users who mistyped a path. This tells both the truth instead.
+ */
+export default function NotFound() {
+  const location = useLocation();
+
+  useEffect(() => {
+    // The SPA fallback serves this at a 200, so the status code can't say
+    // "gone". A robots meta tag is what actually keeps bad URLs out of the index.
+    //
+    // index.html ships a static `robots: index,follow`. Appending a second meta
+    // leaves that permissive one first in the document, so retarget the existing
+    // tag and restore it on unmount rather than adding a competing one.
+    const existing = document.head.querySelector<HTMLMetaElement>('meta[name="robots"]');
+    const meta = existing ?? document.createElement("meta");
+    const previousContent = existing?.content ?? null;
+
+    meta.name = "robots";
+    meta.content = "noindex,follow";
+    if (!existing) document.head.appendChild(meta);
+
+    const previousTitle = document.title;
+    document.title = "Page not found — AI Advantage Sports";
+
+    return () => {
+      if (previousContent === null) meta.remove();
+      else meta.content = previousContent;
+      document.title = previousTitle;
+    };
+  }, []);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-[#05070d] px-5 py-16 text-slate-100">
+      <div className="w-full max-w-xl">
+        <div className="inline-flex items-center gap-2 rounded-lg border border-[#b9ff55]/25 bg-[#b9ff55]/[0.07] px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-[#b9ff55]">
+          <Compass className="h-3.5 w-3.5" aria-hidden="true" />
+          404
+        </div>
+
+        <h1 className="mt-5 text-3xl font-bold tracking-tight text-white sm:text-4xl">
+          That page isn&rsquo;t on the desk.
+        </h1>
+        <p className="mt-3 text-sm leading-6 text-slate-400">
+          No route matches{" "}
+          <code className="rounded bg-white/[0.06] px-1.5 py-0.5 font-mono text-xs text-slate-300">
+            {location.pathname}
+          </code>
+          . It may have moved, or the link may be stale.
+        </p>
+
+        <div className="mt-8 grid gap-2">
+          {SUGGESTIONS.map((item) => (
+            <Link
+              key={item.to}
+              to={item.to}
+              className="group flex items-center justify-between gap-4 rounded-xl border border-white/10 bg-white/[0.03] px-4 py-3 transition-colors hover:border-[#b9ff55]/30 hover:bg-white/[0.06]"
+            >
+              <span>
+                <span className="block text-sm font-semibold text-white">{item.label}</span>
+                <span className="mt-0.5 block text-xs text-slate-500">{item.detail}</span>
+              </span>
+              <span aria-hidden="true" className="text-slate-600 transition-colors group-hover:text-[#b9ff55]">
+                &rarr;
+              </span>
+            </Link>
+          ))}
+        </div>
+
+        <Button
+          asChild
+          variant="outline"
+          className="mt-6 border-white/10 bg-white/[0.02] text-slate-300 hover:bg-white/[0.06] hover:text-white"
+        >
+          <Link to="/">
+            <ArrowLeft className="mr-2 h-4 w-4" aria-hidden="true" />
+            Back to the desk
+          </Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { useDocumentMeta } from "@/lib/useDocumentMeta";
 import { Link, useNavigate } from "react-router-dom";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -56,6 +57,13 @@ function shorten(value: string, start = 8, end = 6): string {
 }
 
 export default function Profile() {
+  useDocumentMeta({
+    title: "Your Account — AI Advantage Sports",
+    description: "Manage your AI Advantage Sports subscription, bankroll defaults, and session.",
+    canonicalPath: "/profile",
+    robots: "noindex,follow",
+  });
+
   const navigate = useNavigate();
   const [access, setAccess] = useState<AccessState>(getAccessState());
   const [cryptoAccount, setCryptoAccount] = useState<CryptoAccessAccount | null>(getCurrentCryptoAccount());

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, type FormEvent } from "react";
+import { useDocumentMeta } from "@/lib/useDocumentMeta";
 import { Link, useNavigate } from "react-router-dom";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -10,6 +11,12 @@ import { Check, Sparkles, UserPlus } from "lucide-react";
 import BrandedHeader from "@/components/BrandedHeader";
 
 export default function Signup() {
+  useDocumentMeta({
+    title: "Create Account — AI Advantage Sports",
+    description: "Create an AI Advantage Sports account to track picks, sizing, and settled proof.",
+    canonicalPath: "/signup",
+  });
+
   const navigate = useNavigate();
   const { toast } = useToast();
   const [email, setEmail] = useState("");

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -9,6 +9,7 @@
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
     "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,


### PR DESCRIPTION
Site improvements found by rendering the app in a browser rather than only reading the source.

> **Heads up for the reviewer:** this branch also carries a one-line fix for a typecheck break that came from `main` (see §7). `main` is currently red on its own — merging this repairs it.

## 1. Mobile navigation was missing entirely

Below `lg`, the header collapsed to the logo and the "Open desk" CTA. The section links (`lg:flex`), "Log in" / "Account" (`sm:inline-flex`), and "Restore" (`xl:inline-flex`) were each hidden behind a breakpoint with nothing standing in for them. Measured at 390px before the change:

```
VISIBLE HEADER CONTROLS @390px: ["A+AI Advantage Sports…", "Open desk"]
```

A phone visitor could not log in or reach their profile at all — and "Open desk" starts checkout rather than navigating. Adds `MobileNav`, built on Radix Dialog so it gets a focus trap, Escape handling, and scroll lock. The desktop header renders byte-identically.

## 2. The site advertised a price it does not charge

The JSON-LD in `index.html` and the prerendered marketing block in `scripts/prerender.mjs` both listed Pro Monthly at **$19**, while the pricing card and checkout used **$15**. Crawlers, Google rich results, and no-JS viewers were quoted the wrong number.

Prices now live in `src/data/pricing.json`, read by the pricing cards, `PaymentOptionDialog`, and the prerender step — which also regenerates the JSON-LD `offers` array so a hand-edit to `index.html` cannot silently ship. `src/lib/pricing.test.ts` fails the build if the copies diverge, confirmed by reintroducing the old value:

```
AssertionError: JSON-LD offer for "Pro Monthly": expected '19' to be '15'
```

## 3. Unknown routes were a soft 404

The catch-all route in `src/App.tsx` matched `path="*"` and rendered a `Navigate` to `/` with `replace`. That served homepage content at HTTP 200 for every bad URL and silently teleported anyone who mistyped a path. It now renders a real `NotFound` page.

Because the SPA fallback serves it at 200, the status code cannot signal "gone", so the page sets `robots: noindex,follow`. It *retargets* the existing meta rather than appending one — `index.html` ships a static `index,follow`, and a second tag leaves the permissive one first in the document.

## 4. Every route shipped the same title — and canonicalized itself away

All six routes inherited the static head from `index.html`: one title, one description, and the same `link rel=canonical` pointing at the homepage.

`sitemap.xml` submits `/`, `/daily-picks`, `/leaderboard`, `/login`, and `/signup` for indexing. Four of those five simultaneously told crawlers they were duplicates of the homepage. The sitemap and the pages were arguing, and the canonical wins that argument — the submitted URLs were asking to be deindexed.

Adds `useDocumentMeta`, setting title, description, canonical, and robots per route and restoring the `index.html` defaults on unmount. Defaults are captured once at module load rather than per-mount, so a route that forgets the hook inherits site defaults instead of a stale neighbour's title. `/profile` is `noindex,follow` — an account surface, correctly absent from the sitemap.

Applied client-side after hydration, since Netlify serves the SPA fallback. Crawlers that execute JS pick it up; a per-route prerendered head would be strictly better and is the natural follow-up if these routes matter for organic traffic.

## 5. Accessibility

- **All six homepage sliders were unnamed**, plus the min-execution-edge slider on `/daily-picks`. `aria-label` was being spread onto the Radix `Root`, but Radix puts `role="slider"` on the `Thumb`. The label is now routed to the thumb, with `aria-valuetext` so a `0.25` Kelly fraction announces as "25%".
- Sport toggles gained `aria-pressed` and a labelled group.
- The board repolls every 60s with no announcement; a compact `role="status"` line now carries the update.
- Team logos gained intrinsic `width`/`height` plus `loading="lazy"`.

## 6. Fonts blocked first paint

The Google Fonts stylesheet was a render-blocking third-party round trip. It now loads via `media="print"` with an `onload` promotion to `all`, plus a `noscript` fallback. `display=swap` was already set.

## 7. Inherited typecheck break from main

CI went red here after merging `main`. The failure is **not** from this branch — 1f49662 ("move sign-out handling to auth.ts") uses `AccessState` at `auth.ts:20` and `:37` but never imports it:

```
src/lib/auth.ts(20,20): error TS2304: Cannot find name 'AccessState'.
src/lib/auth.ts(37,19): error TS2304: Cannot find name 'AccessState'.
```

Reproduced on 1f49662 in a clean worktree with this branch nowhere in the tree — `main` is red on its own, and every branch cut from it inherits a failing typecheck. Fixed here with a **type-only** import, which TypeScript erases at compile time, so no runtime `auth.ts -> stripe.ts` edge is reintroduced and the point of the refactor stands.

### Worth a look separately (not changed here)

That same commit left `accessHydrated` and `serverAccess` in `auth.ts` written but never read (two new lint warnings). They shadow the real state, which lives in `stripe.ts`, so `auth.ts`'s local `clearAccess` mutates copies nothing consumes. There is also a same-name collision: a local `clearAccess`/`emitAccessChange` alongside `export ... from "@/lib/stripe"` for those same names.

**No live defect today** — all three call sites (`Index`, `Profile`, `AccessSessionDialog`) import `signOutAccessSession` from `@/lib/stripe`, so sign-out still clears real state. But the file's own comments tell callers to migrate to `auth.ts`, and doing so would silently get the version that clears dead state. Left alone rather than rewriting a refactor mid-flight.

## Verification

- `npm run lint` — 0 errors (4 warnings: 2 pre-existing `react-refresh`, 2 from the merged commit noted above)
- `npx tsc -b --force` — clean (CI's exact command)
- `npm test` — 57 passed
- `npm run build` — succeeds; output carries `$0` / `$15` / `$10` in both the JSON-LD and the prerendered block
- Browser pass over all seven routes at desktop and mobile: distinct titles, correct self-referential canonicals, `noindex` where intended, no unnamed sliders, no horizontal overflow, no console errors, and metadata correctly restored across client-side navigation

Not verified against the Netlify deploy preview — the authoring environment's network policy blocks outbound hosts, so live ESPN market data was never exercised. Worth a glance at the preview before merge.

## Note, not changed

`AGENTS.md` lists the ETH donation address as `0xAc7C…3515b`, while `src/pages/Index.tsx` uses `0x6f27…36e9`. I left both alone — a payment address is not something to reconcile on inference. Worth confirming which is correct.