### PR TITLE
Cross-link the desk surfaces so Daily Picks and Proof Ledger are not dead ends

### DIFF
--- a/src/components/DeskNav.tsx
+++ b/src/components/DeskNav.tsx
@@ -1,0 +1,53 @@
+import { Link } from "react-router-dom";
+import { ShieldCheck, Trophy } from "lucide-react";
+
+/**
+ * Cross-links between the desk surfaces.
+ *
+ * /daily-picks and /leaderboard each rendered exactly one link — "Back" to the
+ * homepage — at every viewport. A subscriber reading the Daily Picks board who
+ * wanted the Proof Ledger had to go home and hunt for it. This replaces the
+ * static centred page title with the same label plus its sibling, so the two
+ * paid surfaces reach each other directly.
+ *
+ * The current page stays visually dominant, so the bar still reads as a title.
+ */
+
+const SURFACES = [
+  { to: "/daily-picks", label: "Daily Picks", icon: Trophy, activeIcon: "text-yellow-300" },
+  { to: "/leaderboard", label: "Proof Ledger", icon: ShieldCheck, activeIcon: "text-brand-300" },
+] as const;
+
+export default function DeskNav({ current }: { current: "/daily-picks" | "/leaderboard" }) {
+  return (
+    <nav aria-label="Desk surfaces" className="flex items-center gap-1 sm:gap-2">
+      {SURFACES.map(({ to, label, icon: Icon, activeIcon }) => {
+        const isCurrent = to === current;
+
+        if (isCurrent) {
+          return (
+            <span
+              key={to}
+              aria-current="page"
+              className="inline-flex items-center gap-2 rounded-lg px-2 py-1 text-sm font-semibold text-white"
+            >
+              <Icon className={`h-5 w-5 ${activeIcon}`} aria-hidden="true" />
+              {label}
+            </span>
+          );
+        }
+
+        return (
+          <Link
+            key={to}
+            to={to}
+            className="inline-flex items-center gap-1.5 rounded-lg px-2 py-1 text-sm text-zinc-500 transition-colors hover:bg-white/[0.06] hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400/70"
+          >
+            <Icon className="h-4 w-4" aria-hidden="true" />
+            <span className="hidden sm:inline">{label}</span>
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/pages/DailyPicks.tsx
+++ b/src/pages/DailyPicks.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState, useRef } from "react";
+import DeskNav from "@/components/DeskNav";
 import { useDocumentMeta } from "@/lib/useDocumentMeta";
 import { Link } from "react-router-dom";
 import { Badge } from "@/components/ui/badge";
@@ -17,7 +18,6 @@ import {
   RefreshCw,
   Star,
   Target,
-  Trophy,
   User,
   Zap,
 } from "lucide-react";
@@ -848,10 +848,7 @@ export default function DailyPicks() {
               Back
             </Link>
           </Button>
-          <div className="flex items-center gap-2 text-sm font-semibold text-white">
-            <Trophy className="h-5 w-5 text-yellow-300" />
-            Daily Picks
-          </div>
+          <DeskNav current="/daily-picks" />
           <div className="w-16" />
         </div>
 

--- a/src/pages/Leaderboard.tsx
+++ b/src/pages/Leaderboard.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import DeskNav from "@/components/DeskNav";
 import { useDocumentMeta } from "@/lib/useDocumentMeta";
 import { Link } from "react-router-dom";
 import { Badge } from "@/components/ui/badge";
@@ -359,10 +360,7 @@ export default function Leaderboard() {
               Back
             </Link>
           </Button>
-          <div className="flex items-center gap-2 text-sm font-semibold text-white">
-            <ShieldCheck className="h-5 w-5 text-brand-300" />
-            Proof Ledger
-          </div>
+          <DeskNav current="/leaderboard" />
           <Button
             size="sm"
             variant="outline"


### PR DESCRIPTION
Follow-up to #92, on a fresh branch since that one is merged.

## The problem

`/daily-picks` and `/leaderboard` each rendered exactly one link — "Back" to the homepage. Not a mobile-only gap; this was true at every viewport. Measured against the current build:

```
/daily-picks -> visible link hrefs: ["/"]
/leaderboard -> visible link hrefs: ["/"]
```

These are the two paid surfaces. A subscriber reading the Daily Picks board who wanted the Proof Ledger had to navigate home and hunt for the entry point, and vice versa.

## The change

Adds `DeskNav`, replacing the static centred page title with the same label plus its sibling as a link.

- The current page stays bold white with its coloured icon and carries `aria-current="page"`, so the bar still reads as a title rather than turning into a tab strip.
- On small viewports the inactive entry collapses to its icon, protecting the bar's three-column layout.
- Both pages already had the same bar shape (back / title / slot), so it drops in without disturbing either layout: Daily Picks keeps its right-hand spacer, Proof Ledger keeps its CSV export button.

Also drops the `Trophy` import from `DailyPicks.tsx`, which the change left unused.

## Verification

- `npx tsc -b --force` — clean (CI's exact command)
- `npm run lint` — 0 errors, back to the 2 pre-existing `react-refresh` warnings
- `npm test` — 57 passed
- `npm run build` — succeeds
- Browser pass at 1440px and 390px on both pages: each now exposes its sibling, `aria-current` resolves to the correct entry, no horizontal overflow, no console errors, and the Daily Picks to Proof Ledger round trip navigates and updates the title

Re-ran the seven-route audit from #92 to confirm nothing regressed.

## Still open (not addressed here)

`auth.ts` has a same-name collision left from the sign-out refactor: a module-local `clearAccess` and `emitAccessChange` alongside `export { clearAccess } from "@/lib/stripe"` and `export { emitAccessChange } from "@/lib/stripe"` for those same names. Callers importing them from `auth.ts` get stripe's versions, while `signOutAccessSession` internally calls the local ones. No live defect — the call sites all import from `stripe.ts` — but it is a trap for the migration the file's own comments recommend. Left alone since that refactor is still in flight.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdPKFZwNqyNihKVYGXB63L)_