### PR TITLE
fix: make AUTH_SECRET rotation survivable instead of account-ending

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ STRIPE_ONE_TIME_PRICE_ID=price_...
 STRIPE_WEBHOOK_SECRET=whsec_...
 STRIPE_TRIAL_DAYS=7
 PUBLIC_APP_URL=https://aiadvantagesports.com
-AUTH_SECRET=...   # dedicated value; rotating it locks out every account
+AUTH_SECRET=...            # dedicated value, not a borrowed credential
+AUTH_SECRET_PREVIOUS=...   # optional; old secrets still accepted, re-hashed on login
 ```
 
 Webhook endpoint: `https://aiadvantagesports.com/.netlify/functions/stripe-webhook`  

--- a/env.example
+++ b/env.example
@@ -53,11 +53,16 @@ EXECUTION_LEDGER_KEY=ai-advantage:execution-ledger
 # Required for trusted server-side writers that update the shared ledger API.
 # Do not expose this as a VITE_* variable or send it from browser clients.
 EXECUTION_LEDGER_WRITE_TOKEN=replace_with_a_long_random_secret
-# Pepper mixed into every password hash. Set a dedicated value and treat it as
-# permanent: rotating it invalidates every stored password and locks out every
-# account. If unset, auth falls back to UPSTASH_REDIS_REST_TOKEN, which makes a
-# routine database-credential rotation do exactly that.
+# Pepper mixed into every password hash. If unset, auth falls back to
+# UPSTASH_REDIS_REST_TOKEN, so set a dedicated value.
 AUTH_SECRET=replace_with_a_long_random_server_secret
+# Changing AUTH_SECRET makes every existing hash unverifiable. List the old
+# secret(s) here, comma separated, and those logins keep working — each password
+# is re-hashed with the active secret on next login, so the list drains itself
+# and can be removed once traffic has cycled through. The public local-dev
+# secret and UPSTASH_REDIS_REST_TOKEN are accepted automatically, so moving off
+# the borrowed-token fallback needs no entry here.
+# AUTH_SECRET_PREVIOUS=the_previous_secret,an_older_one
 
 # The Odds API (server-side live sports lines)
 # Sign up at https://the-odds-api.com/ to get your API key.

--- a/netlify/functions/_lib/auth.test.ts
+++ b/netlify/functions/_lib/auth.test.ts
@@ -4,12 +4,14 @@ import {
   hashPassword,
   normalizeEmail,
   normalizeUsername,
+  getPreviousAuthSecrets,
   validationError,
   verifyPassword,
 } from "../auth";
 
 const SALT = "0123456789abcdef0123456789abcdef";
-const originalSecret = process.env.AUTH_SECRET;
+const ENV_KEYS = ["AUTH_SECRET", "AUTH_SECRET_PREVIOUS", "UPSTASH_REDIS_REST_TOKEN"] as const;
+const originalEnv: Record<string, string | undefined> = {};
 
 function storedUser(passwordHash: string, passwordSalt = SALT) {
   return {
@@ -25,12 +27,18 @@ function storedUser(passwordHash: string, passwordSalt = SALT) {
 }
 
 beforeEach(() => {
+  for (const key of ENV_KEYS) {
+    originalEnv[key] = process.env[key];
+    delete process.env[key];
+  }
   process.env.AUTH_SECRET = "test-secret-alpha";
 });
 
 afterEach(() => {
-  if (originalSecret === undefined) delete process.env.AUTH_SECRET;
-  else process.env.AUTH_SECRET = originalSecret;
+  for (const key of ENV_KEYS) {
+    if (originalEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = originalEnv[key];
+  }
 });
 
 describe("validationError", () => {
@@ -109,15 +117,44 @@ describe("verifyPassword", () => {
     expect(await verifyPassword("wrong horse", user)).toMatchObject({ ok: false });
   });
 
-  it("locks every account out if the hashing secret changes", async () => {
-    // Documents a real operational hazard rather than asserting desired behaviour:
-    // the secret is a pepper mixed into every hash, and only the local-dev secret
-    // has a migration path. Rotating it invalidates all stored passwords.
-    // getAuthSecret() falls back to UPSTASH_REDIS_REST_TOKEN, so rotating that
-    // database credential — an ordinary operation — would trigger exactly this.
+  it("still accepts a password hashed under a superseded secret", async () => {
+    // Rotating the pepper used to invalidate every stored hash permanently.
+    // Naming the old secret in AUTH_SECRET_PREVIOUS keeps those logins working
+    // and flags them for re-hashing.
+    const user = storedUser(await hashPassword("correct horse", SALT));
+
+    process.env.AUTH_SECRET = "test-secret-beta";
+    process.env.AUTH_SECRET_PREVIOUS = "test-secret-alpha";
+
+    expect(await verifyPassword("correct horse", user)).toMatchObject({ ok: true, needsRehash: true });
+    expect(await verifyPassword("wrong horse", user)).toMatchObject({ ok: false });
+  });
+
+  it("rescues accounts hashed while the Upstash token was standing in as the pepper", async () => {
+    process.env.AUTH_SECRET = "";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "upstash-token-value";
+    const user = storedUser(await hashPassword("correct horse", SALT));
+
+    // Operator sets a dedicated secret; the borrowed token is still accepted.
+    process.env.AUTH_SECRET = "test-secret-beta";
+    expect(await verifyPassword("correct horse", user)).toMatchObject({ ok: true, needsRehash: true });
+  });
+
+  it("still rejects a rotation with no record of the old secret", async () => {
     const user = storedUser(await hashPassword("correct horse", SALT));
 
     process.env.AUTH_SECRET = "test-secret-beta";
     expect(await verifyPassword("correct horse", user)).toMatchObject({ ok: false });
+  });
+
+  it("accepts several superseded secrets and caps how many it will try", async () => {
+    const user = storedUser(await hashPassword("correct horse", SALT));
+
+    process.env.AUTH_SECRET = "test-secret-beta";
+    process.env.AUTH_SECRET_PREVIOUS = " older-one , test-secret-alpha ,, another ";
+    expect(await verifyPassword("correct horse", user)).toMatchObject({ ok: true, needsRehash: true });
+
+    expect(getPreviousAuthSecrets().length).toBeLessThanOrEqual(4);
+    expect(getPreviousAuthSecrets()).not.toContain("test-secret-beta");
   });
 });

--- a/netlify/functions/auth.ts
+++ b/netlify/functions/auth.ts
@@ -341,7 +341,8 @@ function getAuthSecret() {
       warnedAboutBorrowedSecret = true;
       console.warn(
         "[auth] AUTH_SECRET is not set; falling back to UPSTASH_REDIS_REST_TOKEN to hash passwords. " +
-          "Rotating that token will lock out every account. Set AUTH_SECRET to a dedicated value.",
+          "Set AUTH_SECRET to a dedicated value — existing logins keep working, because the " +
+          "borrowed token stays accepted for verification and each password is re-hashed on next login.",
       );
     }
     return borrowed;
@@ -376,17 +377,49 @@ function hashesMatch(storedHash: string, candidateHash: string) {
   return expected.length === actual.length && timingSafeEqual(expected, actual);
 }
 
+/** Cap the pbkdf2 work a single login can trigger. */
+const MAX_PREVIOUS_SECRETS = 4;
+
+/**
+ * Secrets accepted for verification but never for hashing.
+ *
+ * The secret is a pepper mixed into every password hash, so changing it makes
+ * every stored hash unverifiable. Without a list like this, rotating it locks
+ * out every account permanently — and `getAuthSecret` falls back to
+ * `UPSTASH_REDIS_REST_TOKEN`, which made rotating an ordinary database
+ * credential do exactly that.
+ *
+ * Anything matched here is re-hashed with the active secret on next login, so a
+ * rotation drains itself as users return.
+ */
+export function getPreviousAuthSecrets(): string[] {
+  const active = getAuthSecret();
+  const candidates = [
+    ...(process.env.AUTH_SECRET_PREVIOUS || "")
+      .split(",")
+      .map((value) => value.trim())
+      .filter(Boolean),
+    // Accounts created before AUTH_SECRET was set were hashed with the public
+    // local-dev constant, or with the borrowed Upstash token.
+    LOCAL_AUTH_SECRET,
+    process.env.UPSTASH_REDIS_REST_TOKEN || "",
+  ].filter(Boolean);
+
+  return Array.from(new Set(candidates))
+    .filter((secret) => secret !== active)
+    .slice(0, MAX_PREVIOUS_SECRETS);
+}
+
 export async function verifyPassword(password: string, user: StoredSiteUser) {
   const nextHash = await hashPassword(password, user.passwordSalt);
   if (hashesMatch(user.passwordHash, nextHash)) {
     return { ok: true, needsRehash: false };
   }
 
-  // Migration: accounts created before AUTH_SECRET was configured were hashed with the
-  // public local-dev constant. Accept those once and re-hash with the active secret.
-  const activeSecret = getAuthSecret();
-  if (activeSecret && activeSecret !== LOCAL_AUTH_SECRET) {
-    const legacyHash = await hashPasswordWith(LOCAL_AUTH_SECRET, password, user.passwordSalt);
+  // Accept a hash made under a superseded secret once, then let the caller
+  // re-hash it with the active one.
+  for (const previous of getPreviousAuthSecrets()) {
+    const legacyHash = await hashPasswordWith(previous, password, user.passwordSalt);
     if (hashesMatch(user.passwordHash, legacyHash)) {
       return { ok: true, needsRehash: true };
     }


### PR DESCRIPTION
This is the fix for the hazard #96 could only document.

## The problem

The auth secret is a **pepper mixed into every password hash**, so changing it makes every stored hash unverifiable. `verifyPassword` recognised exactly one superseded secret — the public local-dev constant — so any other change locked out every account, permanently.

And `getAuthSecret()` falls back to `UPSTASH_REDIS_REST_TOKEN` when `AUTH_SECRET` is unset, which meant **rotating an ordinary database credential did exactly that, silently.**

In #96 I flagged this and asked whether `AUTH_SECRET` was set in production, because the safe move looked different in each case: if set, delete the fallback; if not, plan a migration. That framing was too narrow. There's a fix that's correct either way — **make rotation survivable rather than catastrophic**, which is the standard key-rotation pattern and something the codebase should have regardless of today's config.

## The fix

`verifyPassword` now accepts a list of superseded secrets. The rehash-on-login path already existed (`auth.ts:581`) — it just only knew about one legacy secret — so each password is re-hashed with the active secret as users return and **a rotation drains itself.**

Accepted for verification, never for hashing:

| Source | Purpose |
|---|---|
| `AUTH_SECRET_PREVIOUS` (comma separated) | deliberate rotations |
| the public local-dev constant | unchanged from before |
| `UPSTASH_REDIS_REST_TOKEN` | lets a deployment that hashed against the borrowed token move to a dedicated `AUTH_SECRET` **without locking anyone out** |

That third row is what makes the production question moot: whichever state you're in, moving to a dedicated secret is now safe and needs no entry in `AUTH_SECRET_PREVIOUS`.

Capped at four candidates so one login can't trigger unbounded pbkdf2 work.

## Also

- The borrowed-token warning now points at the migration instead of only naming the danger.
- `env.example` and the README document the rotation procedure, including that the list can be removed once traffic has cycled through.

## Tests

Replaces the test that pinned the lockout as unavoidable with four:

- a password hashed under a superseded secret still logs in, flagged `needsRehash`
- an account hashed while the Upstash token stood in as the pepper is rescued
- a rotation with **no** record of the old secret is still correctly rejected — this fix doesn't weaken verification
- multiple superseded secrets parse (whitespace, empty entries) and the cap holds

Reverting the change fails three of them.

## Verification

- **Tests** — 102 passed
- **Typecheck** `tsc -b --force` — clean
- **Lint** — 0 errors (2 pre-existing `react-refresh` warnings)
- **Build** — clean

## What this does not do

It can't recover accounts whose original secret is already gone — if a rotation happened before this shipped and the old value wasn't kept, those hashes stay unverifiable and those users need a password reset. This prevents the next occurrence; it can't undo a previous one.

I also still can't verify any of it against production auth traffic from here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uu6R2oWB7x9mLcznV8JPaV)_