### PR TITLE
Report a market-feed outage instead of claiming the desk passed

### DIFF
--- a/src/lib/liveSports.test.ts
+++ b/src/lib/liveSports.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchLiveGamesForSports, LiveMarketUnavailableError } from "./liveSports";
+
+/**
+ * These cover one distinction: an unreachable market feed is not the same as a
+ * day with no games. The fetch used to collapse both into `[]`, which made the
+ * error branches on the homepage, Daily Picks, and the Proof Ledger dead code —
+ * an outage rendered as "the desk is passing instead of inventing a signal."
+ */
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+/** Routes by URL so the primary API and the ESPN fallback can fail independently. */
+function stubFetch(handler: (url: string) => Promise<Response> | Response) {
+  globalThis.fetch = vi.fn((input: RequestInfo | URL) =>
+    Promise.resolve(handler(String(input))),
+  ) as unknown as typeof fetch;
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("fetchLiveGamesForSports", () => {
+  it("throws when the primary API and every ESPN fallback fail", async () => {
+    stubFetch(() => {
+      throw new Error("network down");
+    });
+
+    await expect(fetchLiveGamesForSports(["nba"])).rejects.toBeInstanceOf(LiveMarketUnavailableError);
+  });
+
+  it("resolves empty when the primary API reports a genuinely empty slate", async () => {
+    stubFetch((url) => {
+      if (url.includes("/api/sports-lines")) return jsonResponse({ games: [] });
+      throw new Error("ESPN should not be consulted after a successful primary call");
+    });
+
+    await expect(fetchLiveGamesForSports(["nba"])).resolves.toEqual([]);
+  });
+
+  it("returns the primary API slate when it answers", async () => {
+    const games = [{ id: "g1" }];
+    stubFetch((url) => {
+      if (url.includes("/api/sports-lines")) return jsonResponse({ games });
+      throw new Error("unexpected fallback");
+    });
+
+    await expect(fetchLiveGamesForSports(["nba"])).resolves.toEqual(games);
+  });
+
+  it("does not throw when the primary API fails but a fallback slate lands", async () => {
+    stubFetch((url) => {
+      if (url.includes("/api/sports-lines")) throw new Error("function offline");
+      // An ESPN scoreboard with no events is a reachable source reporting no games.
+      return jsonResponse({ events: [] });
+    });
+
+    await expect(fetchLiveGamesForSports(["nba"])).resolves.toEqual([]);
+  });
+
+  it("resolves empty for an empty sport list rather than reporting an outage", async () => {
+    stubFetch(() => {
+      throw new Error("should not be called");
+    });
+
+    await expect(fetchLiveGamesForSports([])).resolves.toEqual([]);
+  });
+});

--- a/src/lib/liveSports.ts
+++ b/src/lib/liveSports.ts
@@ -364,10 +364,38 @@ async function fetchEspnLiveGamesForSport(sport: Sport, date = new Date()): Prom
     });
 }
 
+/**
+ * Every market source failed, so the board has no idea what today's slate is.
+ *
+ * This is deliberately distinct from "the sources answered and there are no
+ * games": callers must be able to tell an outage from a quiet day. See
+ * fetchLiveGamesForSports for why that distinction matters here.
+ */
+export class LiveMarketUnavailableError extends Error {
+  constructor(message = "Live market board unavailable right now.") {
+    super(message);
+    this.name = "LiveMarketUnavailableError";
+  }
+}
+
 export async function fetchLiveGamesForSport(sport: Sport, date = new Date()): Promise<LiveMarketGame[]> {
   return fetchLiveGamesForSports([sport], date);
 }
 
+/**
+ * Resolves with the slate, or throws LiveMarketUnavailableError when no source
+ * could be reached.
+ *
+ * This used to swallow every failure and resolve with `[]`: the primary call sat
+ * in a catch-all, and the ESPN fallback mapped rejected slates to empty arrays.
+ * The error branches on the homepage, Daily Picks, and the Proof Ledger were
+ * therefore unreachable — a total feed outage rendered as "no execution-qualified
+ * rows, the desk is passing instead of inventing a signal."
+ *
+ * That is the one thing this product must not say when it isn't true. Passing is
+ * a model judgement; having no data is not. An empty resolve still means a real
+ * empty slate, so a quiet Tuesday reads exactly as it did before.
+ */
 export async function fetchLiveGamesForSports(sports: Sport[], date = new Date()): Promise<LiveMarketGame[]> {
   const dateKey = toDateKey(date);
   const params = new URLSearchParams({
@@ -390,9 +418,19 @@ export async function fetchLiveGamesForSports(sports: Sport[], date = new Date()
       return payload.games;
     }
   } catch {
-    // Keep local Vite development useful when Netlify functions are not running.
+    // Fall through to ESPN. This keeps local Vite development useful when the
+    // Netlify functions are not running, and covers a provider blip in prod.
   }
 
+  if (sports.length === 0) return [];
+
   const slates = await Promise.allSettled(sports.map((sport) => fetchEspnLiveGamesForSport(sport, date)));
+
+  // The primary API already failed to get us here. If the fallback did not land
+  // for a single requested sport either, we know nothing about the slate.
+  if (slates.every((slate) => slate.status === "rejected")) {
+    throw new LiveMarketUnavailableError();
+  }
+
   return slates.flatMap((slate) => (slate.status === "fulfilled" ? slate.value : []));
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -702,22 +702,29 @@ Bet responsibly. This is model output, not a guarantee.`);
                         }`}
                       >
                         <span className={`h-1.5 w-1.5 rounded-full ${featuredEntry ? "bg-[#b9ff55]" : "bg-amber-300"}`} />
-                        {featuredEntry ? "Qualified" : "Pass"}
+                        {featuredEntry ? "Qualified" : liveSlateError ? "No feed" : "Pass"}
                       </span>
                     </div>
 
                     <h1 className="mt-4 max-w-4xl text-3xl font-bold tracking-[-0.035em] text-white sm:text-4xl lg:text-[42px]">
-                      {featuredEntry?.eventLabel ?? "The desk is passing the current slate"}
+                      {featuredEntry?.eventLabel ??
+                        (liveSlateError
+                          ? "The market feed is unavailable"
+                          : "The desk is passing the current slate")}
                     </h1>
                     <div className="mt-2 font-mono text-xs font-semibold uppercase tracking-[0.08em] text-cyan-200 sm:text-sm">
                       {featuredEntry
                         ? `${featuredEntry.recommendedSide} ${featuredEntry.summary.line} · ${featuredEntry.bookmaker ?? "Public consensus"}`
-                        : `No edge clears ${minEdge}% after execution filters`}
+                        : liveSlateError
+                          ? "No verified market data to price against"
+                          : `No edge clears ${minEdge}% after execution filters`}
                     </div>
                     <p className="mt-4 max-w-3xl text-sm leading-6 text-slate-400">
                       {featuredEntry
                         ? `The model remains ${formatEdge(featuredEntry.executionAdjustedEdge)} above the implied market after timing, volatility, and liquidity discounts.`
-                        : "No fabricated signal. Adjust the controls or wait for the next verified market update."}
+                        : liveSlateError
+                          ? "This is an outage, not a pass. The desk will not call a slate it cannot see."
+                          : "No fabricated signal. Adjust the controls or wait for the next verified market update."}
                     </p>
                   </div>
 
@@ -733,7 +740,11 @@ Bet responsibly. This is model output, not a guarantee.`);
                       },
                       {
                         label: "Execution edge",
-                        value: featuredEntry ? formatEdge(featuredEntry.executionAdjustedEdge) : "Pass",
+                        value: featuredEntry
+                          ? formatEdge(featuredEntry.executionAdjustedEdge)
+                          : liveSlateError
+                            ? "—"
+                            : "Pass",
                       },
                       {
                         label: "Kelly stake",
@@ -958,7 +969,7 @@ Bet responsibly. This is model output, not a guarantee.`);
                     </div>
                     <div>
                       <div className="font-mono text-lg font-semibold text-white">
-                        {executionBoardEntries.length ? formatEdge(avgEdge) : "Pass"}
+                        {executionBoardEntries.length ? formatEdge(avgEdge) : liveSlateError ? "—" : "Pass"}
                       </div>
                       <div className="mt-1 text-[9px] uppercase tracking-[0.12em] text-slate-400">Avg edge</div>
                     </div>


### PR DESCRIPTION
## The bug

`fetchLiveGamesForSports` could never fail. The primary `/api/sports-lines` call sat inside a catch-all, and the ESPN fallback mapped every rejected slate to `[]`:

```
} catch {
  // Keep local Vite development useful when Netlify functions are not running.
}

const slates = await Promise.allSettled(sports.map(...));
return slates.flatMap((slate) => (slate.status === "fulfilled" ? slate.value : []));
```

It always resolved, so callers could not distinguish **"the feed is unreachable"** from **"there are no games today."**

That made the error branches on the homepage (two of them), Daily Picks, and the Proof Ledger unreachable code. With every source down, the site rendered its *empty* state instead — "No execution-qualified rows. The desk is passing instead of inventing a signal," under a hero reading "The desk is passing the current slate."

Passing is a model judgement. Having no data is not. For a product whose whole claim is that it publishes proof and declines to invent signal, an outage dressed up as a considered pass is the one thing it must not say. It also hid outages from users completely — while the hourly smoke workflow exists precisely to catch a dead board.

## The fix

`fetchLiveGamesForSports` now throws `LiveMarketUnavailableError` when the primary call fails **and** every requested ESPN slate rejects. A reachable source reporting zero games still resolves empty, so a genuinely quiet slate reads exactly as it did before.

**No new UI was needed.** The error copy on all three pages was already written and already good — the Proof Ledger's *"the ledger is staying honest and showing nothing instead of inventing a board"* was clearly written for this exact case. It just could never render.

The homepage hero did need the distinction, because it keys off `featuredEntry` rather than the error. During an outage it now reads "The market feed is unavailable / This is an outage, not a pass. The desk will not call a slate it cannot see", badges **No feed** rather than **Pass**, and blanks the execution-edge and average-edge readouts instead of reporting "Pass".

## Verification

- `npx tsc -b --force` — clean (CI's exact command)
- `npm run lint` — 0 errors (2 pre-existing `react-refresh` warnings)
- `npm test` — 104 passed (99 pre-existing + 5 new)
- `npm run build` — succeeds

`liveSports.test.ts` covers the distinction in both directions. Removing the throw fails the outage case while leaving the empty-slate cases green:

```
FAIL  throws when the primary API and every ESPN fallback fail
Tests  1 failed | 4 passed (5)
```

This sandbox blocks the market APIs, so it reproduces a real outage end to end. Before, the homepage claimed a pass; now all three pages state the outage, with no false pass claim at 1280px or 390px and no console errors:

```
desktop  falsePass=false | outage=true | overflow=0 | errs=none
mobile   falsePass=false | outage=true | overflow=0 | errs=none
```

Also worth noting: `LiveOddsTicker` already handled this correctly ("FEED OFFLINE"), so the page is now internally consistent rather than the ticker contradicting the hero.

## Not changed

Measured performance while looking for work here and found nothing worth touching — FCP 224ms, LCP 224ms, CLS 0.0000, 172KB transferred, 1 script on mobile. Recording it so nobody re-derives it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdPKFZwNqyNihKVYGXB63L)_