### PR TITLE
Add Hermes -> Substack publishing script

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Production does **not** fall back to Payment Links when Checkout Sessions fail (
 
 The homepage form posts to `/api/newsletter-subscribe`, which creates a Notion entry, emails a notification, and redirects into the Substack subscribe flow.
 
+For publishing *into* Substack (posting content, as opposed to capturing subscribers), see [`docs/hermes-substack.md`](docs/hermes-substack.md) — a standalone script the Hermes agent runs to push posts to `allowayai.substack.com`.
+
 ```bash
 NOTION_API_KEY=***
 NOTION_PARENT_PAGE_ID=...

--- a/docs/hermes-substack.md
+++ b/docs/hermes-substack.md
@@ -1,0 +1,89 @@
+# Hermes → Substack publishing
+
+`scripts/hermes-substack-publish.mjs` lets your Hermes agent (wherever it
+runs — e.g. locally on your DappNode) publish posts to your Substack
+publication (`allowayai.substack.com`).
+
+This is a standalone script, not a deployed part of this app. Hermes invokes
+it directly (cron, systemd timer, or ad hoc) with its own process and its own
+credentials — nothing here goes through Netlify.
+
+## Why a script instead of a repo API endpoint
+
+Substack has no official public API. Publishing works by driving the same
+undocumented JSON endpoints the Substack web editor itself calls
+(`/api/v1/drafts`, `.../prepublish`, `.../publish`), authenticated with a
+logged-in session cookie. Those endpoints can change without notice, and
+using them may be outside what Substack's terms of service anticipate for
+your own account — review Substack's current terms before relying on this
+for anything unattended. Because of that fragility, this lives as a script
+Hermes controls directly rather than a hosted endpoint other systems depend on.
+
+## Setup
+
+1. Copy the relevant vars from `env.example` into wherever Hermes reads its
+   environment from (its own `.env`, systemd unit, etc — not this repo's
+   Netlify env, since the script never runs there):
+
+   ```bash
+   SUBSTACK_PUBLICATION_URL=https://allowayai.substack.com
+   SUBSTACK_SID=...
+   SUBSTACK_CONNECT_SID=...
+   ```
+
+2. Get the two cookie values from a browser logged into Substack:
+   DevTools → Application → Cookies → `https://substack.com` → copy the
+   `substack.sid` and `connect.sid` values.
+
+   These are session cookies — they expire, and rotate on password change or
+   the occasional forced logout. When the script starts failing auth, refresh
+   them the same way. As a fallback, `SUBSTACK_EMAIL` / `SUBSTACK_PASSWORD`
+   makes the script log in fresh on every run, but Substack can require a
+   captcha on scripted logins, so cookie auth is the reliable path.
+
+## Usage
+
+```bash
+node scripts/hermes-substack-publish.mjs post.json          # draft only (safe default)
+node scripts/hermes-substack-publish.mjs post.json --publish # creates draft AND publishes it
+node scripts/hermes-substack-publish.mjs post.json --dry-run # no network calls, just prints the payload
+```
+
+`post.json`:
+
+```json
+{
+  "title": "Post title",
+  "subtitle": "Optional subtitle",
+  "body": "Markdown content...\n\nSupports **bold**, *italic*, `code`, [links](https://example.com), lists, blockquotes, and fenced code blocks.",
+  "sendEmail": true,
+  "shareSocial": false
+}
+```
+
+`body` is Markdown (a practical subset — see
+`scripts/lib/substack-markdown.mjs`), converted to the ProseMirror JSON
+structure Substack's draft API expects.
+
+## Safety model
+
+- **Draft-only by default.** Without `--publish`, the script only creates a
+  Substack draft and prints its edit URL (`{pub}/publish/post/{id}`) — no
+  subscriber ever sees it. Publishing (and emailing your list) requires the
+  explicit `--publish` flag.
+- **`sendEmail` / `shareSocial`** default to `true` / `false` when
+  publishing (matching Substack's own default), overridable per-post in
+  `post.json` or via `SUBSTACK_SEND_EMAIL` / `SUBSTACK_SHARE_SOCIAL` env vars.
+- Non-zero exit code on any failure (bad auth, bad payload, network error),
+  so Hermes/cron can detect and alert on failed runs.
+
+## Example: Hermes cron on the DappNode
+
+```bash
+# crontab -e
+0 9 * * * cd /path/to/hermes && node ai-advantage/scripts/hermes-substack-publish.mjs \
+  out/todays-post.json --publish >> /var/log/hermes-substack.log 2>&1
+```
+
+Point Hermes at generating `post.json`; this script is only the last-mile
+delivery step into Substack.

--- a/env.example
+++ b/env.example
@@ -44,6 +44,21 @@ NOTIFY_EMAIL=ian@allowayllc.com
 # Used by hourly edge alerts (send-edge-alerts) and daily trial nudges (send-trial-nudge).
 SUBSTACK_PUBLICATION_URL=https://allowayai.substack.com
 
+# Hermes -> Substack publishing (scripts/hermes-substack-publish.mjs)
+# Standalone script run by the Hermes agent wherever it lives (not part of
+# the deployed app/Netlify env). See docs/hermes-substack.md.
+# Get cookie values from a logged-in browser: DevTools -> Application ->
+# Cookies -> https://substack.com -> "substack.sid" / "connect.sid".
+SUBSTACK_SID=
+SUBSTACK_CONNECT_SID=
+# Fallback if cookies aren't set (Substack may require a captcha on scripted
+# logins, so cookie auth above is preferred).
+# SUBSTACK_EMAIL=
+# SUBSTACK_PASSWORD=
+# Defaults used only when publishing (--publish); overridable per-post.
+# SUBSTACK_SEND_EMAIL=true
+# SUBSTACK_SHARE_SOCIAL=false
+
 # Shared proof ledger storage
 # Optional for account auth because Netlify Blobs is used by default.
 # Recommended for the shared proof ledger if you want Redis-backed row history.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "preview": "vite preview",
     "test": "vitest run --exclude 'tests/smoke/**'",
     "test:smoke": "vitest run tests/smoke",
-    "test:all": "vitest run"
+    "test:all": "vitest run",
+    "hermes:publish": "node scripts/hermes-substack-publish.mjs"
   },
   "dependencies": {
     "@netlify/blobs": "^10.7.11",

--- a/scripts/hermes-substack-publish.mjs
+++ b/scripts/hermes-substack-publish.mjs
@@ -1,0 +1,228 @@
+#!/usr/bin/env node
+// Standalone publisher for the Hermes agent (runs wherever Hermes lives, e.g.
+// on your DappNode) to push a post into your Substack publication.
+//
+// This is NOT part of the deployed app or Netlify functions — it's a script
+// Hermes invokes directly (cron, systemd timer, or ad hoc) with its own
+// process and its own credentials. Substack has no official public API; this
+// drives the same undocumented JSON endpoints the Substack web editor uses,
+// authenticated with a logged-in session cookie. See docs/hermes-substack.md
+// for setup and the safety model.
+//
+// Usage:
+//   node scripts/hermes-substack-publish.mjs <post.json> [--publish] [--dry-run]
+//
+// Without --publish, the script only creates/updates a Substack draft and
+// prints its edit URL — nothing goes out to subscribers. --publish is
+// required to actually publish (and, by default, email your list).
+import { readFile } from "node:fs/promises";
+import { markdownToProseMirrorDoc } from "./lib/substack-markdown.mjs";
+
+function parseArgs(argv) {
+  const args = { publish: false, dryRun: false, file: null };
+  for (const arg of argv) {
+    if (arg === "--publish") args.publish = true;
+    else if (arg === "--dry-run") args.dryRun = true;
+    else if (arg === "--help" || arg === "-h") args.help = true;
+    else if (!arg.startsWith("-")) args.file = arg;
+    else throw new Error(`Unknown flag: ${arg}`);
+  }
+  return args;
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/hermes-substack-publish.mjs <post.json> [--publish] [--dry-run]
+
+post.json shape:
+  {
+    "title": "Post title",           // required
+    "subtitle": "Optional subtitle", // optional
+    "body": "Markdown content...",   // required
+    "sendEmail": true,               // optional, overrides SUBSTACK_SEND_EMAIL
+    "shareSocial": false             // optional, overrides SUBSTACK_SHARE_SOCIAL
+  }
+
+Flags:
+  --publish   Actually publish the draft (default: create/update draft only)
+  --dry-run   Build the request payload and print it; no network calls
+
+Env vars (see env.example):
+  SUBSTACK_PUBLICATION_URL   e.g. https://allowayai.substack.com
+  SUBSTACK_SID               "substack.sid" cookie value
+  SUBSTACK_CONNECT_SID       "connect.sid" cookie value
+  SUBSTACK_EMAIL / SUBSTACK_PASSWORD   fallback login if cookies aren't set
+  SUBSTACK_SEND_EMAIL         default "true" when --publish is used
+  SUBSTACK_SHARE_SOCIAL       default "false" when --publish is used
+`);
+}
+
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing required env var: ${name}`);
+  return value;
+}
+
+function normalizePublicationUrl(rawUrl) {
+  const url = new URL(rawUrl);
+  return `${url.protocol}//${url.host}`;
+}
+
+function publicationSubdomain(baseUrl) {
+  const host = new URL(baseUrl).hostname;
+  return host.endsWith(".substack.com") ? host.split(".")[0] : host;
+}
+
+async function resolveCookieHeader(baseUrl) {
+  const sid = process.env.SUBSTACK_SID;
+  const connectSid = process.env.SUBSTACK_CONNECT_SID;
+  if (sid && connectSid) {
+    return `connect.sid=${connectSid}; substack.sid=${sid}`;
+  }
+
+  const email = process.env.SUBSTACK_EMAIL;
+  const password = process.env.SUBSTACK_PASSWORD;
+  if (!email || !password) {
+    throw new Error(
+      "No auth available. Set SUBSTACK_SID + SUBSTACK_CONNECT_SID (recommended) " +
+        "or SUBSTACK_EMAIL + SUBSTACK_PASSWORD. See docs/hermes-substack.md.",
+    );
+  }
+
+  const response = await fetch("https://substack.com/api/v1/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      email,
+      password,
+      redirect: "/",
+      for_pub: publicationSubdomain(baseUrl),
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(
+      `Login failed (${response.status}). Substack may be blocking scripted logins with a ` +
+        `captcha — use SUBSTACK_SID/SUBSTACK_CONNECT_SID instead. Response: ${text.slice(0, 300)}`,
+    );
+  }
+
+  const setCookies = response.headers.getSetCookie?.() ?? [];
+  const cookiePairs = setCookies
+    .map((cookie) => cookie.split(";")[0])
+    .filter((pair) => pair.startsWith("connect.sid=") || pair.startsWith("substack.sid="));
+
+  if (cookiePairs.length < 2) {
+    throw new Error("Login succeeded but session cookies were not returned as expected.");
+  }
+
+  return cookiePairs.join("; ");
+}
+
+async function substackFetch(baseUrl, cookieHeader, path, init = {}) {
+  const response = await fetch(`${baseUrl}${path}`, {
+    ...init,
+    headers: {
+      cookie: cookieHeader,
+      "content-type": "application/json",
+      ...init.headers,
+    },
+  });
+
+  const text = await response.text();
+  let json;
+  try {
+    json = text ? JSON.parse(text) : {};
+  } catch {
+    json = null;
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Substack API ${init.method ?? "GET"} ${path} failed (${response.status}): ${text.slice(0, 500)}`,
+    );
+  }
+
+  return json;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help || !args.file) {
+    printHelp();
+    process.exit(args.help ? 0 : 1);
+  }
+
+  const raw = await readFile(args.file, "utf8");
+  const post = JSON.parse(raw);
+  if (!post.title) throw new Error("post.json is missing required field: title");
+  if (!post.body) throw new Error("post.json is missing required field: body");
+
+  const baseUrl = normalizePublicationUrl(requireEnv("SUBSTACK_PUBLICATION_URL"));
+  const draftBody = markdownToProseMirrorDoc(post.body);
+
+  const draftPayload = {
+    draft_title: post.title,
+    draft_subtitle: post.subtitle ?? "",
+    draft_body: JSON.stringify(draftBody),
+    type: "newsletter",
+  };
+
+  if (args.dryRun) {
+    console.log(JSON.stringify({ baseUrl, draftPayload, willPublish: args.publish }, null, 2));
+    return;
+  }
+
+  const cookieHeader = await resolveCookieHeader(baseUrl);
+
+  const draft = await substackFetch(baseUrl, cookieHeader, "/api/v1/drafts", {
+    method: "POST",
+    body: JSON.stringify(draftPayload),
+  });
+  const draftId = draft.id;
+  if (!draftId) throw new Error(`Draft create response had no id: ${JSON.stringify(draft)}`);
+
+  // Substack requires prepublish to run before a draft can be published.
+  await substackFetch(baseUrl, cookieHeader, `/api/v1/drafts/${draftId}/prepublish`);
+
+  if (!args.publish) {
+    console.log(
+      JSON.stringify(
+        {
+          status: "draft",
+          id: draftId,
+          editUrl: `${baseUrl}/publish/post/${draftId}`,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  const sendEmail = post.sendEmail ?? (process.env.SUBSTACK_SEND_EMAIL ?? "true") === "true";
+  const shareSocial =
+    post.shareSocial ?? (process.env.SUBSTACK_SHARE_SOCIAL ?? "false") === "true";
+
+  const published = await substackFetch(baseUrl, cookieHeader, `/api/v1/drafts/${draftId}/publish`, {
+    method: "POST",
+    body: JSON.stringify({ send: sendEmail, share_automatically: shareSocial }),
+  });
+
+  console.log(
+    JSON.stringify(
+      {
+        status: "published",
+        id: draftId,
+        url: published.canonical_url ?? `${baseUrl}/p/${published.slug ?? draftId}`,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch((error) => {
+  console.error(`[hermes-substack-publish] ${error.message}`);
+  process.exit(1);
+});

--- a/scripts/lib/substack-markdown.mjs
+++ b/scripts/lib/substack-markdown.mjs
@@ -1,0 +1,102 @@
+// Converts a small Markdown subset into the ProseMirror-shaped JSON document
+// Substack's draft API expects for `draft_body` (headings, paragraphs, bold,
+// italic, inline code, links, bullet/ordered lists, blockquotes, fenced code).
+// Not a full CommonMark implementation — just enough for Hermes-generated post bodies.
+
+const INLINE_PATTERN =
+  /(\*\*(.+?)\*\*|__(.+?)__|`(.+?)`|\[(.+?)\]\((.+?)\)|\*(.+?)\*|_(.+?)_)/g;
+
+function textNode(text, marks) {
+  const node = { type: "text", text };
+  if (marks && marks.length) node.marks = marks;
+  return node;
+}
+
+function parseInline(text) {
+  const nodes = [];
+  let lastIndex = 0;
+  let match;
+  INLINE_PATTERN.lastIndex = 0;
+  while ((match = INLINE_PATTERN.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      nodes.push(textNode(text.slice(lastIndex, match.index)));
+    }
+    if (match[2] !== undefined) nodes.push(textNode(match[2], [{ type: "strong" }]));
+    else if (match[3] !== undefined) nodes.push(textNode(match[3], [{ type: "strong" }]));
+    else if (match[4] !== undefined) nodes.push(textNode(match[4], [{ type: "code" }]));
+    else if (match[5] !== undefined)
+      nodes.push(textNode(match[5], [{ type: "link", attrs: { href: match[6] } }]));
+    else if (match[7] !== undefined) nodes.push(textNode(match[7], [{ type: "em" }]));
+    else if (match[8] !== undefined) nodes.push(textNode(match[8], [{ type: "em" }]));
+    lastIndex = INLINE_PATTERN.lastIndex;
+  }
+  if (lastIndex < text.length) nodes.push(textNode(text.slice(lastIndex)));
+  return nodes.filter((node) => node.text !== "");
+}
+
+function paragraph(text) {
+  const node = { type: "paragraph" };
+  const inline = parseInline(text);
+  if (inline.length) node.content = inline;
+  return node;
+}
+
+function heading(level, text) {
+  const node = { type: "heading", attrs: { level } };
+  const inline = parseInline(text);
+  if (inline.length) node.content = inline;
+  return node;
+}
+
+function parseBlock(block) {
+  const headingMatch = block.match(/^(#{1,3})\s+(.*)$/);
+  if (headingMatch) return heading(headingMatch[1].length, headingMatch[2]);
+
+  if (block.startsWith("```")) {
+    const codeText = block.replace(/^```[^\n]*\n?/, "").replace(/```$/, "");
+    const node = { type: "code_block" };
+    if (codeText) node.content = [{ type: "text", text: codeText }];
+    return node;
+  }
+
+  const lines = block.split("\n");
+
+  if (lines.every((line) => /^>\s?/.test(line))) {
+    const inner = lines.map((line) => line.replace(/^>\s?/, "")).join("\n");
+    return { type: "blockquote", content: [parseBlock(inner)] };
+  }
+
+  if (lines.every((line) => /^[-*]\s+/.test(line))) {
+    return {
+      type: "bullet_list",
+      content: lines.map((line) => ({
+        type: "list_item",
+        content: [paragraph(line.replace(/^[-*]\s+/, ""))],
+      })),
+    };
+  }
+
+  if (lines.every((line) => /^\d+\.\s+/.test(line))) {
+    return {
+      type: "ordered_list",
+      content: lines.map((line) => ({
+        type: "list_item",
+        content: [paragraph(line.replace(/^\d+\.\s+/, ""))],
+      })),
+    };
+  }
+
+  return paragraph(lines.join(" "));
+}
+
+export function markdownToProseMirrorDoc(markdown) {
+  const blocks = String(markdown ?? "")
+    .replace(/\r\n/g, "\n")
+    .trim()
+    .split(/\n{2,}/)
+    .map((block) => block.trim())
+    .filter(Boolean);
+
+  const content = blocks.map(parseBlock);
+  return { type: "doc", content: content.length ? content : [{ type: "paragraph" }] };
+}

--- a/scripts/lib/substack-markdown.test.mjs
+++ b/scripts/lib/substack-markdown.test.mjs
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { markdownToProseMirrorDoc } from "./substack-markdown.mjs";
+
+describe("markdownToProseMirrorDoc", () => {
+  it("wraps plain text in a single paragraph", () => {
+    expect(markdownToProseMirrorDoc("Hello world")).toEqual({
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", text: "Hello world" }] }],
+    });
+  });
+
+  it("splits blank-line-separated blocks into separate paragraphs", () => {
+    const doc = markdownToProseMirrorDoc("First paragraph.\n\nSecond paragraph.");
+    expect(doc.content).toHaveLength(2);
+    expect(doc.content[0].content[0].text).toBe("First paragraph.");
+    expect(doc.content[1].content[0].text).toBe("Second paragraph.");
+  });
+
+  it("parses headings with their level", () => {
+    const doc = markdownToProseMirrorDoc("## A heading");
+    expect(doc.content[0]).toEqual({
+      type: "heading",
+      attrs: { level: 2 },
+      content: [{ type: "text", text: "A heading" }],
+    });
+  });
+
+  it("applies bold, italic, code, and link marks", () => {
+    const doc = markdownToProseMirrorDoc(
+      "This is **bold**, *italic*, `code`, and a [link](https://example.com).",
+    );
+    const nodes = doc.content[0].content;
+
+    expect(nodes).toContainEqual({ type: "text", text: "bold", marks: [{ type: "strong" }] });
+    expect(nodes).toContainEqual({ type: "text", text: "italic", marks: [{ type: "em" }] });
+    expect(nodes).toContainEqual({ type: "text", text: "code", marks: [{ type: "code" }] });
+    expect(nodes).toContainEqual({
+      type: "text",
+      text: "link",
+      marks: [{ type: "link", attrs: { href: "https://example.com" } }],
+    });
+  });
+
+  it("parses bullet lists", () => {
+    const doc = markdownToProseMirrorDoc("- one\n- two\n- three");
+    expect(doc.content[0].type).toBe("bullet_list");
+    expect(doc.content[0].content).toHaveLength(3);
+    expect(doc.content[0].content[1]).toEqual({
+      type: "list_item",
+      content: [{ type: "paragraph", content: [{ type: "text", text: "two" }] }],
+    });
+  });
+
+  it("parses ordered lists", () => {
+    const doc = markdownToProseMirrorDoc("1. one\n2. two");
+    expect(doc.content[0].type).toBe("ordered_list");
+    expect(doc.content[0].content).toHaveLength(2);
+  });
+
+  it("parses blockquotes", () => {
+    const doc = markdownToProseMirrorDoc("> A quoted line");
+    expect(doc.content[0].type).toBe("blockquote");
+    expect(doc.content[0].content[0]).toEqual({
+      type: "paragraph",
+      content: [{ type: "text", text: "A quoted line" }],
+    });
+  });
+
+  it("parses fenced code blocks", () => {
+    const doc = markdownToProseMirrorDoc("```js\nconst x = 1;\n```");
+    expect(doc.content[0]).toEqual({
+      type: "code_block",
+      content: [{ type: "text", text: "const x = 1;\n" }],
+    });
+  });
+
+  it("falls back to a single empty paragraph for empty input", () => {
+    expect(markdownToProseMirrorDoc("")).toEqual({
+      type: "doc",
+      content: [{ type: "paragraph" }],
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `scripts/hermes-substack-publish.mjs`, a standalone script the Hermes agent (wherever it runs — e.g. your DappNode) invokes directly to publish posts to `allowayai.substack.com`. It's not part of the deployed app; it's a script Hermes controls with its own credentials.
- Substack has no official public API, so this drives the same undocumented JSON endpoints the Substack web editor uses (`/api/v1/drafts`, `.../prepublish`, `.../publish`), authenticated with your logged-in session cookies (or email/password as a fallback).
- **Safety default: draft-only.** Without `--publish` it only creates/updates a Substack draft and prints the edit URL — nothing reaches subscribers. `--publish` is required to actually publish and (by default) email your list. `--dry-run` builds the request payload with no network calls at all.
- Adds `scripts/lib/substack-markdown.mjs`, a small Markdown → ProseMirror JSON converter (headings, bold/italic/code/links, lists, blockquotes, fenced code) used to build `draft_body`, plus a unit test suite for it.
- Adds `docs/hermes-substack.md` with setup instructions (where to get the session cookies, env vars, example `post.json`, example cron invocation) and notes the fragility/ToS caveat of relying on an unofficial API.
- Adds the relevant env vars to `env.example`, a `README.md` pointer, and an `npm run hermes:publish` shortcut.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 116/116 passing (includes 9 new tests for the Markdown → ProseMirror converter)
- [x] Manual `--dry-run` smoke test of the CLI against a sample `post.json` — payload shape verified
- [x] Manual `--help` / missing-file argument handling verified
- [ ] End-to-end publish against the real Substack account (needs real session cookies — do this from wherever Hermes actually runs, not this session)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FtRmfuMZkf84jDDoo2cq3E)_