### PR TITLE
Improve SEO: per-route prerendered heads, single metadata source, generated sitemap

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,14 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>AI Advantage Sports - AI-Powered Betting Insights</title>
-    <meta name="description" content="AI Advantage Sports is an execution-first sports intelligence desk with live lines, model probabilities, Kelly sizing, and proof-led betting analysis." />
+    <title>AI Advantage Sports — Live Lines, Model Edge, Kelly Sizing</title>
+    <meta name="description" content="Execution-first sports betting intelligence: live lines, model probabilities, execution-adjusted edge, and quarter-Kelly stake guidance for NBA, NFL, MLB, and the World Cup." />
     <meta name="author" content="AI Advantage Sports" />
     <meta name="robots" content="index,follow" />
     <meta name="theme-color" content="#020617" />
     <meta name="application-name" content="AI Advantage Sports" />
     <link rel="canonical" href="https://aiadvantagesports.com/" />
-    <meta property="og:title" content="AI Advantage Sports - AI-Powered Betting Insights" />
+    <meta property="og:title" content="AI Advantage Sports — Live Lines, Model Edge, Kelly Sizing" />
     <meta property="og:description" content="Live market pulse, model-backed edges, Kelly stake guidance, and proof-led sports betting intelligence." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://aiadvantagesports.com/" />
@@ -20,7 +20,7 @@
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="AI Advantage Sports — Live lines, model edge, better decisions." />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="AI Advantage Sports - AI-Powered Betting Insights" />
+    <meta name="twitter:title" content="AI Advantage Sports — Live Lines, Model Edge, Kelly Sizing" />
     <meta name="twitter:description" content="Execution-first sports betting intelligence with live lines, model edge, and proof-led analysis." />
     <meta name="twitter:image" content="https://aiadvantagesports.com/ai-advantage-social-card.png" />
     <meta name="twitter:image:alt" content="AI Advantage Sports — Live lines, model edge, better decisions." />
@@ -73,6 +73,20 @@
             "price": "10",
             "priceCurrency": "USD"
           }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        "name": "AI Advantage Sports",
+        "url": "https://aiadvantagesports.com/",
+        "logo": "https://aiadvantagesports.com/favicon.svg",
+        "description": "Execution-first sports betting intelligence: live lines, model probabilities, execution-adjusted edge, and quarter-Kelly stake guidance.",
+        "sameAs": [
+          "https://allowayai.substack.com",
+          "https://www.linkedin.com/in/ianit"
         ]
       }
     </script>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,31 +2,31 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://aiadvantagesports.com/</loc>
-    <lastmod>2026-07-28</lastmod>
+    <lastmod>2026-08-15</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://aiadvantagesports.com/daily-picks</loc>
-    <lastmod>2026-07-28</lastmod>
+    <lastmod>2026-08-15</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://aiadvantagesports.com/leaderboard</loc>
-    <lastmod>2026-07-28</lastmod>
+    <lastmod>2026-08-15</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://aiadvantagesports.com/login</loc>
-    <lastmod>2026-07-28</lastmod>
+    <lastmod>2026-08-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://aiadvantagesports.com/signup</loc>
-    <lastmod>2026-07-28</lastmod>
+    <lastmod>2026-08-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.4</priority>
   </url>

--- a/scripts/lib/seo.mjs
+++ b/scripts/lib/seo.mjs
@@ -1,0 +1,219 @@
+// Pure SEO helpers shared by the build-time prerender and sitemap generation.
+//
+// Everything here is a plain string transform with no filesystem or network
+// access, so scripts/lib/seo.test.mjs can exercise it directly. The build step
+// (scripts/prerender.mjs) reads src/data/seo.json, hands the parsed config in,
+// and writes whatever these functions return to dist/.
+//
+// The head-rewriting helpers operate on the already-built dist/index.html: they
+// find a specific tag by its identifying attribute and swap only the value that
+// matters, so they stay correct even if index.html's head is reordered or
+// extended later.
+
+const AMP = /&/g;
+const LT = /</g;
+const GT = />/g;
+const QUOT = /"/g;
+
+/** Escape text that lands in element content (between tags). */
+export function escapeHtml(value) {
+  return String(value).replace(AMP, "&amp;").replace(LT, "&lt;").replace(GT, "&gt;");
+}
+
+/** Escape text that lands inside a double-quoted attribute value. */
+export function escapeAttr(value) {
+  return String(value)
+    .replace(AMP, "&amp;")
+    .replace(LT, "&lt;")
+    .replace(GT, "&gt;")
+    .replace(QUOT, "&quot;");
+}
+
+/** Escape text destined for XML character data (sitemap <loc>). */
+export function escapeXml(value) {
+  return String(value)
+    .replace(AMP, "&amp;")
+    .replace(LT, "&lt;")
+    .replace(GT, "&gt;")
+    .replace(QUOT, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Resolve a route path against the site origin. The homepage keeps its trailing
+ * slash (canonical `https://site/`), every other route is slash-free so the
+ * canonical, the sitemap, and the in-app links all agree on one spelling.
+ */
+export function absoluteUrl(origin, path) {
+  const base = String(origin).replace(/\/+$/, "");
+  if (!path || path === "/") return `${base}/`;
+  return `${base}${path.startsWith("/") ? path : `/${path}`}`;
+}
+
+export function setTitle(html, title) {
+  return html.replace(/<title>[\s\S]*?<\/title>/i, () => `<title>${escapeHtml(title)}</title>`);
+}
+
+/**
+ * Rewrite the `content` of the `<meta>` tag identified by `attr="key"`
+ * (attr is "name" or "property"). Tolerant of attribute order; inserts a
+ * `content` attribute if the matched tag somehow lacks one.
+ */
+export function setMeta(html, attr, key, content) {
+  const tagRe = new RegExp(`<meta\\b[^>]*\\b${attr}="${escapeRegExp(key)}"[^>]*>`, "i");
+  return html.replace(tagRe, (tag) => {
+    if (/\bcontent="/i.test(tag)) {
+      return tag.replace(/(\bcontent=")[^"]*(")/i, () => `content="${escapeAttr(content)}"`);
+    }
+    return tag.replace(/\s*\/?>\s*$/, () => ` content="${escapeAttr(content)}" />`);
+  });
+}
+
+export function setCanonical(html, href) {
+  const tagRe = /<link\b[^>]*\brel="canonical"[^>]*>/i;
+  return html.replace(tagRe, (tag) =>
+    tag.replace(/(\bhref=")[^"]*(")/i, () => `href="${escapeAttr(href)}"`),
+  );
+}
+
+function indentBlock(text, pad) {
+  return text
+    .split("\n")
+    .map((line, index) => (index === 0 ? line : `${pad}${line}`))
+    .join("\n");
+}
+
+/** Replace the first JSON-LD `<script>` block's payload (the homepage clone's
+ *  WebApplication node) with per-page structured data. */
+export function replaceFirstJsonLd(html, jsonText) {
+  const scriptRe = /<script type="application\/ld\+json">[\s\S]*?<\/script>/i;
+  if (!scriptRe.test(html)) return html;
+  return html.replace(
+    scriptRe,
+    () => `<script type="application/ld+json">\n      ${indentBlock(jsonText, "      ")}\n    </script>`,
+  );
+}
+
+/** WebPage + BreadcrumbList graph for a single indexable route. */
+export function buildPageStructuredData(route, config) {
+  const url = absoluteUrl(config.origin, route.path);
+  const home = absoluteUrl(config.origin, "/");
+  const graph = {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "WebPage",
+        name: route.title,
+        description: route.description,
+        url,
+        isPartOf: { "@type": "WebSite", name: config.siteName, url: home },
+        primaryImageOfPage: absoluteUrl(config.origin, config.socialImage),
+      },
+      {
+        "@type": "BreadcrumbList",
+        itemListElement: [
+          { "@type": "ListItem", position: 1, name: "Home", item: home },
+          { "@type": "ListItem", position: 2, name: route.h1 || route.title, item: url },
+        ],
+      },
+    ],
+  };
+  return JSON.stringify(graph, null, 2);
+}
+
+// Static in-page navigation the crawler-facing body links out to. Keeps every
+// prerendered route one hop from the desk's primary surfaces.
+const NAV = [
+  ["/", "Live Desk"],
+  ["/daily-picks", "Daily Picks"],
+  ["/leaderboard", "Proof Ledger"],
+  ["/login", "Log In"],
+];
+
+/**
+ * Minimal but honest static body for a prerendered subroute, injected into the
+ * empty `#root`. createRoot().render() replaces it once the bundle loads, so
+ * this exists purely for crawlers and no-JS clients: a real <h1>, a one-line
+ * description, and internal links.
+ */
+export function buildPrerenderBody(route) {
+  const nav = NAV.map(
+    ([href, label]) =>
+      `<a href="${escapeAttr(href)}" style="color:#94a3b8;margin-right:16px;">${escapeHtml(label)}</a>`,
+  ).join("\n        ");
+  return `
+<div id="prerender-seo" style="min-height:100vh;background:#05070d;color:#e2e8f0;font-family:Inter,system-ui,sans-serif;">
+  <header style="border-bottom:1px solid rgba(255,255,255,0.1);padding:18px 20px;">
+    <strong style="color:#fff;">AI Advantage Sports</strong>
+    <span style="color:#64748b;"> — Sports intelligence, sized and tracked</span>
+    <nav style="margin-top:6px;">
+        ${nav}
+    </nav>
+  </header>
+  <main style="max-width:1120px;margin:0 auto;padding:48px 20px;">
+    <h1 style="font-size:34px;font-weight:600;color:#fff;line-height:1.15;">${escapeHtml(route.h1 || route.title)}</h1>
+    <p style="margin-top:16px;max-width:640px;font-size:18px;line-height:1.6;color:#cbd5e1;">${escapeHtml(route.intro || route.description)}</p>
+  </main>
+  <footer style="border-top:1px solid rgba(255,255,255,0.1);padding:24px 20px;color:#64748b;">
+    AI Advantage Sports — execution-first sports betting intelligence. Bet responsibly; 21+.
+  </footer>
+</div>`;
+}
+
+/**
+ * Rewrite a clone of dist/index.html into the head + body for one subroute:
+ * title, description, robots, canonical, Open Graph / Twitter, per-page
+ * structured data, and the crawler-facing body.
+ */
+export function renderSubroute(baseHtml, route, config, rootMarker) {
+  const url = absoluteUrl(config.origin, route.path);
+  let html = baseHtml;
+  html = setTitle(html, route.title);
+  html = setMeta(html, "name", "description", route.description);
+  html = setMeta(html, "name", "robots", route.robots);
+  html = setCanonical(html, url);
+  html = setMeta(html, "property", "og:title", route.title);
+  html = setMeta(html, "property", "og:description", route.description);
+  html = setMeta(html, "property", "og:url", url);
+  html = setMeta(html, "name", "twitter:title", route.title);
+  html = setMeta(html, "name", "twitter:description", route.description);
+  html = replaceFirstJsonLd(html, buildPageStructuredData(route, config));
+  if (rootMarker && html.includes(rootMarker)) {
+    html = html.replace(rootMarker, () => `<div id="root">${buildPrerenderBody(route)}</div>`);
+  }
+  return html;
+}
+
+/** Routes that belong in the sitemap: opted in via `sitemap` and not noindex. */
+export function sitemapRoutes(routes) {
+  return routes.filter(
+    (route) => route.sitemap && !String(route.robots || "").includes("noindex"),
+  );
+}
+
+export function buildSitemapXml(routes, origin, lastmod) {
+  const entries = sitemapRoutes(routes)
+    .map((route) => {
+      const loc = escapeXml(absoluteUrl(origin, route.path));
+      const priority = Number(route.sitemap.priority).toFixed(1);
+      return [
+        "  <url>",
+        `    <loc>${loc}</loc>`,
+        `    <lastmod>${lastmod}</lastmod>`,
+        `    <changefreq>${route.sitemap.changefreq}</changefreq>`,
+        `    <priority>${priority}</priority>`,
+        "  </url>",
+      ].join("\n");
+    })
+    .join("\n");
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${entries}\n</urlset>\n`;
+}
+
+/** Routes that get their own prerendered dist/<path>/index.html. */
+export function prerenderRoutes(routes) {
+  return routes.filter((route) => route.prerender);
+}

--- a/scripts/lib/seo.test.mjs
+++ b/scripts/lib/seo.test.mjs
@@ -1,0 +1,233 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  absoluteUrl,
+  buildPageStructuredData,
+  buildSitemapXml,
+  escapeAttr,
+  escapeHtml,
+  escapeXml,
+  prerenderRoutes,
+  renderSubroute,
+  replaceFirstJsonLd,
+  setCanonical,
+  setMeta,
+  setTitle,
+  sitemapRoutes,
+} from "./seo.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+const config = {
+  origin: "https://example.com",
+  siteName: "Example Desk",
+  socialImage: "/card.png",
+};
+
+const route = {
+  path: "/daily-picks",
+  title: "Daily Picks — Example Desk",
+  description: "Every qualified play with edge, stake, and window.",
+  h1: "Daily Picks",
+  intro: "Every qualified play, graded.",
+  robots: "index,follow",
+};
+
+// A stand-in for the built dist/index.html head: homepage values that a
+// subroute clone must overwrite, plus two JSON-LD blocks to prove only the
+// first is rewritten.
+const BASE_HTML = `<!DOCTYPE html><html><head>
+<title>Home — Example Desk</title>
+<meta name="description" content="Home description." />
+<meta name="robots" content="index,follow" />
+<link rel="canonical" href="https://example.com/" />
+<meta property="og:title" content="Home — Example Desk" />
+<meta property="og:description" content="Home og description." />
+<meta property="og:url" content="https://example.com/" />
+<meta name="twitter:title" content="Home — Example Desk" />
+<meta name="twitter:description" content="Home twitter description." />
+<script type="application/ld+json">
+      { "@type": "WebApplication", "name": "Example Desk" }
+    </script>
+<script type="application/ld+json">
+      { "@type": "Organization", "name": "Example Desk" }
+    </script>
+</head><body><div id="root"></div></body></html>`;
+
+const ROOT = '<div id="root"></div>';
+
+describe("escaping", () => {
+  it("escapes element content", () => {
+    expect(escapeHtml('a & b < c > d')).toBe("a &amp; b &lt; c &gt; d");
+  });
+  it("escapes attribute values including quotes", () => {
+    expect(escapeAttr('say "hi" & <bye>')).toBe("say &quot;hi&quot; &amp; &lt;bye&gt;");
+  });
+  it("escapes xml including apostrophes", () => {
+    expect(escapeXml("Tom's & Jerry's")).toBe("Tom&apos;s &amp; Jerry&apos;s");
+  });
+});
+
+describe("absoluteUrl", () => {
+  it("keeps the homepage trailing slash", () => {
+    expect(absoluteUrl("https://example.com", "/")).toBe("https://example.com/");
+  });
+  it("resolves a subroute without a trailing slash", () => {
+    expect(absoluteUrl("https://example.com", "/daily-picks")).toBe(
+      "https://example.com/daily-picks",
+    );
+  });
+  it("normalizes a trailing slash on the origin", () => {
+    expect(absoluteUrl("https://example.com/", "/leaderboard")).toBe(
+      "https://example.com/leaderboard",
+    );
+  });
+});
+
+describe("head rewriting", () => {
+  it("replaces the title", () => {
+    expect(setTitle(BASE_HTML, "New Title")).toContain("<title>New Title</title>");
+  });
+
+  it("rewrites a meta by name regardless of attribute order", () => {
+    const reordered = '<meta content="old" name="description" />';
+    expect(setMeta(reordered, "name", "description", "fresh")).toBe(
+      '<meta content="fresh" name="description" />',
+    );
+  });
+
+  it("rewrites an og property meta", () => {
+    const out = setMeta(BASE_HTML, "property", "og:title", "Subroute Title");
+    expect(out).toContain('<meta property="og:title" content="Subroute Title" />');
+    // Only the og:title changes; og:description is untouched.
+    expect(out).toContain('content="Home og description."');
+  });
+
+  it("inserts a content attribute when the matched tag lacks one", () => {
+    const out = setMeta('<meta name="robots" />', "name", "robots", "noindex,follow");
+    expect(out).toBe('<meta name="robots" content="noindex,follow" />');
+  });
+
+  it("escapes rewritten attribute values", () => {
+    const out = setMeta(BASE_HTML, "name", "description", 'A "quoted" & <angled> value');
+    expect(out).toContain('content="A &quot;quoted&quot; &amp; &lt;angled&gt; value"');
+  });
+
+  it("rewrites the canonical href", () => {
+    const out = setCanonical(BASE_HTML, "https://example.com/daily-picks");
+    expect(out).toContain('<link rel="canonical" href="https://example.com/daily-picks" />');
+  });
+
+  it("replaces only the first JSON-LD block", () => {
+    const out = replaceFirstJsonLd(BASE_HTML, '{\n  "@type": "WebPage"\n}');
+    expect(out).toContain('"@type": "WebPage"');
+    expect(out).not.toContain('"@type": "WebApplication"');
+    // The Organization block (second) survives.
+    expect(out).toContain('"@type": "Organization"');
+  });
+});
+
+describe("buildPageStructuredData", () => {
+  it("emits a WebPage + BreadcrumbList graph for the route", () => {
+    const parsed = JSON.parse(buildPageStructuredData(route, config));
+    const [page, crumbs] = parsed["@graph"];
+    expect(page["@type"]).toBe("WebPage");
+    expect(page.url).toBe("https://example.com/daily-picks");
+    expect(page.isPartOf.url).toBe("https://example.com/");
+    expect(crumbs["@type"]).toBe("BreadcrumbList");
+    expect(crumbs.itemListElement.at(-1).item).toBe("https://example.com/daily-picks");
+  });
+});
+
+describe("renderSubroute", () => {
+  const out = renderSubroute(BASE_HTML, route, config, ROOT);
+
+  it("rewrites the whole head for the route", () => {
+    expect(out).toContain(`<title>${route.title}</title>`);
+    expect(out).toContain('<link rel="canonical" href="https://example.com/daily-picks" />');
+    expect(out).toContain('<meta property="og:url" content="https://example.com/daily-picks" />');
+    expect(out).toContain('<meta name="twitter:title" content="Daily Picks — Example Desk" />');
+    expect(out).toContain('"@type": "WebPage"');
+    expect(out).not.toContain('"@type": "WebApplication"');
+  });
+
+  it("injects a crawler-facing body with an h1 and internal links", () => {
+    expect(out).toContain("<h1");
+    expect(out).toContain(route.h1);
+    expect(out).toContain('href="/daily-picks"');
+    expect(out).toContain('href="/leaderboard"');
+    expect(out).not.toContain(ROOT); // root marker was consumed
+  });
+});
+
+describe("sitemap", () => {
+  const routes = [
+    { path: "/", robots: "index,follow", sitemap: { priority: 1.0, changefreq: "daily" } },
+    { path: "/daily-picks", robots: "index,follow", sitemap: { priority: 0.9, changefreq: "daily" } },
+    { path: "/profile", robots: "noindex,follow", sitemap: { priority: 0.5, changefreq: "monthly" } },
+    { path: "/about", robots: "index,follow" },
+  ];
+
+  it("selects only indexable, opted-in routes", () => {
+    expect(sitemapRoutes(routes).map((r) => r.path)).toEqual(["/", "/daily-picks"]);
+  });
+
+  it("builds valid xml with fixed lastmod and one-decimal priority", () => {
+    const xml = buildSitemapXml(routes, "https://example.com", "2026-08-15");
+    expect(xml).toContain("<loc>https://example.com/</loc>");
+    expect(xml).toContain("<loc>https://example.com/daily-picks</loc>");
+    expect(xml).not.toContain("/profile");
+    expect(xml).not.toContain("/about");
+    expect(xml).toContain("<lastmod>2026-08-15</lastmod>");
+    expect(xml).toContain("<priority>1.0</priority>");
+    expect(xml).toContain("<priority>0.9</priority>");
+  });
+});
+
+describe("src/data/seo.json integrity", () => {
+  it("is internally consistent", async () => {
+    const raw = await readFile(join(here, "..", "..", "src", "data", "seo.json"), "utf8");
+    const seo = JSON.parse(raw);
+
+    expect(seo.origin).toMatch(/^https:\/\//);
+    expect(seo.origin).not.toMatch(/\/$/); // no trailing slash; helpers add it
+
+    const paths = seo.routes.map((r) => r.path);
+    expect(new Set(paths).size).toBe(paths.length); // unique
+
+    for (const r of seo.routes) {
+      expect(r.path.startsWith("/")).toBe(true);
+      expect(typeof r.title).toBe("string");
+      expect(r.title.length).toBeGreaterThan(0);
+      expect(typeof r.description).toBe("string");
+      expect(r.description.length).toBeGreaterThan(0);
+      expect(r.robots).toMatch(/^(index|noindex),(follow|nofollow)$/);
+      if (r.prerender) {
+        // A prerendered subroute needs a heading and a lead line for its body.
+        expect(typeof r.h1).toBe("string");
+        expect(typeof r.intro).toBe("string");
+      }
+    }
+
+    // Nothing noindex is ever advertised in the sitemap.
+    for (const r of sitemapRoutes(seo.routes)) {
+      expect(r.robots).not.toContain("noindex");
+      expect(r.sitemap.changefreq).toMatch(/^(always|hourly|daily|weekly|monthly|yearly|never)$/);
+      expect(r.sitemap.priority).toBeGreaterThanOrEqual(0);
+      expect(r.sitemap.priority).toBeLessThanOrEqual(1);
+    }
+
+    // The homepage is canonical and indexable; it is not a generated subroute.
+    const home = seo.routes.find((r) => r.path === "/");
+    expect(home).toBeTruthy();
+    expect(home.prerender).toBe(false);
+    expect(home.robots).toBe("index,follow");
+
+    // Every prerender target is reachable as a distinct file path.
+    for (const r of prerenderRoutes(seo.routes)) {
+      expect(r.path).not.toBe("/");
+    }
+  });
+});

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -1,26 +1,46 @@
-// Build-time prerender of the homepage marketing content.
+// Build-time prerender + static SEO generation.
 //
 // The app is a client-rendered SPA, so a raw `dist/index.html` ships an empty
 // `<div id="root">` — invisible to crawlers, no-JS viewers, and "view source".
-// This injects the real, static marketing copy into #root so the initial HTML
-// is meaningful. main.tsx uses createRoot().render() (not hydrate), so React
-// cleanly replaces this content once the bundle loads — no hydration mismatch.
+// This step makes the served HTML meaningful for every route:
 //
-// Pure string injection: no headless browser, no network. If anything is off,
-// it logs and exits 0 so a prerender hiccup can never fail the production build.
-import { readFile, writeFile } from "node:fs/promises";
+//   1. Homepage: injects the real marketing copy into #root and keeps the
+//      WebApplication `offers` JSON-LD in sync with pricing.json.
+//   2. Subroutes (from src/data/seo.json): writes dist/<route>/index.html with a
+//      per-route <head> (title, description, canonical, Open Graph, per-page
+//      structured data) and a small crawler-facing body. Without this, the SPA
+//      fallback hands every subroute the homepage's head — including a canonical
+//      that points back at "/", telling crawlers each page is a homepage dupe.
+//   3. sitemap.xml: regenerated from seo.json with a fresh lastmod.
+//
+// main.tsx uses createRoot().render() (not hydrate), so React cleanly replaces
+// any injected content once the bundle loads — no hydration mismatch.
+//
+// Pure string injection: no headless browser, no network. Each stage is wrapped
+// so a hiccup logs and is skipped rather than failing the production build.
+import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
+import {
+  buildSitemapXml,
+  prerenderRoutes,
+  renderSubroute,
+} from "./lib/seo.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const indexPath = join(here, "..", "dist", "index.html");
+const distDir = join(here, "..", "dist");
+const indexPath = join(distDir, "index.html");
 const pricingPath = join(here, "..", "src", "data", "pricing.json");
+const seoPath = join(here, "..", "src", "data", "seo.json");
 
 // Prices come from the same JSON the pricing cards render from, so the
 // prerendered copy and the JSON-LD offers can never advertise a number that
 // checkout does not charge.
 const pricing = JSON.parse(await readFile(pricingPath, "utf8"));
 const planById = (id) => pricing.plans.find((plan) => plan.id === id);
+
+const seo = JSON.parse(await readFile(seoPath, "utf8"));
+const seoConfig = { origin: seo.origin, siteName: seo.siteName, socialImage: seo.socialImage };
 
 const sections = [
   {
@@ -106,7 +126,9 @@ const ROOT_EMPTY = '<div id="root"></div>';
 
 // Rewrite the WebApplication JSON-LD `offers` array from pricing.json. index.html
 // is hand-maintained, so this makes the shipped structured data authoritative
-// even if someone edits a price there and forgets the JSON.
+// even if someone edits a price there and forgets the JSON. It targets the first
+// JSON-LD block (WebApplication); the Organization block that follows is left as
+// written.
 function syncStructuredDataOffers(html) {
   const offers = pricing.plans.map((plan) => ({
     "@type": "Offer",
@@ -146,10 +168,47 @@ function syncStructuredDataOffers(html) {
   );
 }
 
+// Regenerate dist/sitemap.xml from seo.json with today's date, so lastmod tracks
+// the deploy instead of a hand-edited constant that silently goes stale.
+async function writeSitemap() {
+  const lastmod = new Date().toISOString().slice(0, 10);
+  const xml = buildSitemapXml(seo.routes, seo.origin, lastmod);
+  await writeFile(join(distDir, "sitemap.xml"), xml);
+  console.log(`[prerender] Wrote dist/sitemap.xml (${lastmod})`);
+}
+
+// Emit dist/<route>/index.html for each opted-in route. Directory-index files
+// are served by Netlify at the clean URL and take precedence over the SPA
+// fallback rewrite; if this stage is skipped the fallback still serves the app.
+async function writeSubroutes(baseHtml) {
+  for (const route of prerenderRoutes(seo.routes)) {
+    const html = renderSubroute(baseHtml, route, seoConfig, ROOT_EMPTY);
+    const outDir = join(distDir, route.path.replace(/^\/+/, ""));
+    await mkdir(outDir, { recursive: true });
+    await writeFile(join(outDir, "index.html"), html);
+    console.log(`[prerender] Wrote dist${route.path}/index.html`);
+  }
+}
+
 try {
   const html = await readFile(indexPath, "utf8");
+
+  // Independent of the SPA root marker, so run it first and on its own.
+  try {
+    await writeSitemap();
+  } catch (error) {
+    console.warn("[prerender] sitemap skipped (non-fatal):", error?.message ?? error);
+  }
+
+  // Subroutes derive from the pristine (empty-root, homepage-head) index.html.
+  try {
+    await writeSubroutes(html);
+  } catch (error) {
+    console.warn("[prerender] subroutes skipped (non-fatal):", error?.message ?? error);
+  }
+
   if (!html.includes(ROOT_EMPTY)) {
-    console.warn("[prerender] '<div id=\"root\"></div>' not found in dist/index.html; skipping injection.");
+    console.warn("[prerender] '<div id=\"root\"></div>' not found in dist/index.html; skipping homepage injection.");
     process.exit(0);
   }
   let next = html.replace(ROOT_EMPTY, () => `<div id="root">${prerenderHtml}</div>`);

--- a/src/data/seo.json
+++ b/src/data/seo.json
@@ -1,0 +1,66 @@
+{
+  "origin": "https://aiadvantagesports.com",
+  "siteName": "AI Advantage Sports",
+  "socialImage": "/ai-advantage-social-card.png",
+  "routes": [
+    {
+      "path": "/",
+      "title": "AI Advantage Sports — Live Lines, Model Edge, Kelly Sizing",
+      "description": "Execution-first sports betting intelligence: live lines, model probabilities, execution-adjusted edge, and quarter-Kelly stake guidance for NBA, NFL, MLB, and the World Cup.",
+      "robots": "index,follow",
+      "prerender": false,
+      "sitemap": { "priority": 1.0, "changefreq": "daily" }
+    },
+    {
+      "path": "/daily-picks",
+      "title": "Daily Picks — AI Advantage Sports",
+      "description": "The full execution board: every qualified play with model probability, execution-adjusted edge, recommended stake, and entry window.",
+      "h1": "Daily Picks",
+      "intro": "The full execution board — every qualified play graded on model probability, execution-adjusted edge, recommended stake, and entry window.",
+      "robots": "index,follow",
+      "prerender": true,
+      "sitemap": { "priority": 0.9, "changefreq": "daily" }
+    },
+    {
+      "path": "/leaderboard",
+      "title": "Proof Ledger — AI Advantage Sports",
+      "description": "The public settled record: graded picks, closing-line value, and calibration history for every recommendation the desk has made.",
+      "h1": "Proof Ledger",
+      "intro": "The public settled record — graded picks, closing-line value, and calibration history for every recommendation the desk has made.",
+      "robots": "index,follow",
+      "prerender": true,
+      "sitemap": { "priority": 0.8, "changefreq": "daily" }
+    },
+    {
+      "path": "/login",
+      "title": "Log In — AI Advantage Sports",
+      "description": "Log in to AI Advantage Sports to reach your execution desk and proof ledger.",
+      "h1": "Log In",
+      "intro": "Log in to reach your execution desk, saved bankroll defaults, and proof ledger.",
+      "robots": "index,follow",
+      "prerender": true,
+      "sitemap": { "priority": 0.4, "changefreq": "monthly" }
+    },
+    {
+      "path": "/signup",
+      "title": "Create Account — AI Advantage Sports",
+      "description": "Create an AI Advantage Sports account to track picks, sizing, and settled proof.",
+      "h1": "Create Your Account",
+      "intro": "Create an account to track picks, size stakes with quarter-Kelly, and follow the settled proof ledger.",
+      "robots": "index,follow",
+      "prerender": true,
+      "sitemap": { "priority": 0.4, "changefreq": "monthly" }
+    },
+    {
+      "path": "/profile",
+      "title": "Your Account — AI Advantage Sports",
+      "description": "Manage your AI Advantage Sports subscription, bankroll defaults, and session.",
+      "robots": "noindex,follow",
+      "prerender": false
+    }
+  ],
+  "notFound": {
+    "title": "Page not found — AI Advantage Sports",
+    "robots": "noindex,follow"
+  }
+}

--- a/src/lib/routeSeo.ts
+++ b/src/lib/routeSeo.ts
@@ -1,0 +1,43 @@
+import seo from "@/data/seo.json";
+import type { DocumentMeta } from "@/lib/useDocumentMeta";
+
+/**
+ * Typed access to the per-route SEO copy in src/data/seo.json — the single
+ * source shared by the pages (this hook input), the build-time prerender
+ * (dist/<route>/index.html heads), and the sitemap generator. Editing a title
+ * or description in one place updates the rendered page, the crawlable static
+ * head, and the sitemap together, so they can no longer drift apart.
+ */
+
+interface RouteEntry {
+  path: string;
+  title: string;
+  description: string;
+  robots?: string;
+}
+
+const byPath = new Map<string, RouteEntry>(
+  (seo.routes as RouteEntry[]).map((route) => [route.path, route]),
+);
+
+/** Metadata for a known route path, shaped for {@link useDocumentMeta}. */
+export function routeMeta(path: string): DocumentMeta {
+  const entry = byPath.get(path);
+  if (!entry) {
+    // A route missing from seo.json still gets a self-referential canonical
+    // rather than silently inheriting the homepage's.
+    return { title: seo.siteName, canonicalPath: path };
+  }
+  return {
+    title: entry.title,
+    description: entry.description,
+    canonicalPath: entry.path,
+    robots: entry.robots,
+  };
+}
+
+/** Metadata for the catch-all 404 route (kept out of the index). */
+export const notFoundMeta: DocumentMeta = {
+  title: seo.notFound.title,
+  robots: seo.notFound.robots,
+};

--- a/src/lib/useDocumentMeta.ts
+++ b/src/lib/useDocumentMeta.ts
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import seo from "@/data/seo.json";
 
 /**
  * Per-route document metadata for a client-rendered SPA.
@@ -10,13 +11,14 @@ import { useEffect } from "react";
  * told crawlers it was a duplicate of the homepage. The sitemap and the pages
  * were arguing, and the canonical wins.
  *
- * Netlify serves the SPA fallback, so this is set client-side after hydration
- * rather than in the served HTML. Crawlers that execute JS pick it up; a
- * server-rendered or per-route prerendered head would be strictly better and is
- * the natural follow-up if these routes matter for organic traffic.
+ * The build now prerenders a correct <head> into dist/<route>/index.html, so
+ * this hook is the client-side counterpart: it keeps the same tags accurate
+ * after in-app navigation and for any route that is not prerendered. Open Graph
+ * and Twitter title/description/url are derived from the same title/description
+ * so a share of the current route never advertises the homepage's card.
  */
 
-export const SITE_ORIGIN = "https://aiadvantagesports.com";
+export const SITE_ORIGIN: string = seo.origin;
 
 export interface DocumentMeta {
   title: string;
@@ -27,14 +29,14 @@ export interface DocumentMeta {
   robots?: string;
 }
 
-function upsertMeta(name: string, content: string): void {
-  let tag = document.head.querySelector<HTMLMetaElement>(`meta[name="${name}"]`);
+function upsertMeta(attr: "name" | "property", key: string, content: string): void {
+  let tag = document.head.querySelector<HTMLMetaElement>(`meta[${attr}="${key}"]`);
   if (!tag) {
     tag = document.createElement("meta");
-    tag.name = name;
+    tag.setAttribute(attr, key);
     document.head.appendChild(tag);
   }
-  tag.content = content;
+  tag.setAttribute("content", content);
 }
 
 function upsertCanonical(href: string): void {
@@ -47,38 +49,61 @@ function upsertCanonical(href: string): void {
   link.href = href;
 }
 
+function readMeta(attr: "name" | "property", key: string): string {
+  return document.head.querySelector<HTMLMetaElement>(`meta[${attr}="${key}"]`)?.content ?? "";
+}
+
 // Captured once, before any route has overwritten them, so unmount restores the
 // index.html values rather than whatever the previously mounted route set. A
 // route that forgets to call this hook then inherits the site defaults instead
 // of a stale neighbour's title.
 const defaults = {
   title: typeof document === "undefined" ? "" : document.title,
-  description:
-    typeof document === "undefined"
-      ? ""
-      : (document.head.querySelector<HTMLMetaElement>('meta[name="description"]')?.content ?? ""),
+  description: typeof document === "undefined" ? "" : readMeta("name", "description"),
   canonical:
     typeof document === "undefined"
       ? `${SITE_ORIGIN}/`
       : (document.head.querySelector<HTMLLinkElement>('link[rel="canonical"]')?.href ?? `${SITE_ORIGIN}/`),
-  robots:
-    typeof document === "undefined"
-      ? "index,follow"
-      : (document.head.querySelector<HTMLMetaElement>('meta[name="robots"]')?.content ?? "index,follow"),
+  robots: typeof document === "undefined" ? "index,follow" : readMeta("name", "robots") || "index,follow",
+  ogTitle: typeof document === "undefined" ? "" : readMeta("property", "og:title"),
+  ogDescription: typeof document === "undefined" ? "" : readMeta("property", "og:description"),
+  ogUrl: typeof document === "undefined" ? `${SITE_ORIGIN}/` : readMeta("property", "og:url"),
+  twitterTitle: typeof document === "undefined" ? "" : readMeta("name", "twitter:title"),
+  twitterDescription: typeof document === "undefined" ? "" : readMeta("name", "twitter:description"),
 };
 
 export function useDocumentMeta({ title, description, canonicalPath, robots }: DocumentMeta): void {
   useEffect(() => {
     document.title = title;
-    if (description) upsertMeta("description", description);
-    if (canonicalPath) upsertCanonical(`${SITE_ORIGIN}${canonicalPath}`);
-    if (robots) upsertMeta("robots", robots);
+    upsertMeta("property", "og:title", title);
+    upsertMeta("name", "twitter:title", title);
+
+    if (description) {
+      upsertMeta("name", "description", description);
+      upsertMeta("property", "og:description", description);
+      upsertMeta("name", "twitter:description", description);
+    }
+    if (canonicalPath) {
+      const url = `${SITE_ORIGIN}${canonicalPath}`;
+      upsertCanonical(url);
+      upsertMeta("property", "og:url", url);
+    }
+    if (robots) upsertMeta("name", "robots", robots);
 
     return () => {
       document.title = defaults.title;
-      if (description) upsertMeta("description", defaults.description);
-      if (canonicalPath) upsertCanonical(defaults.canonical);
-      if (robots) upsertMeta("robots", defaults.robots);
+      upsertMeta("property", "og:title", defaults.ogTitle);
+      upsertMeta("name", "twitter:title", defaults.twitterTitle);
+      if (description) {
+        upsertMeta("name", "description", defaults.description);
+        upsertMeta("property", "og:description", defaults.ogDescription);
+        upsertMeta("name", "twitter:description", defaults.twitterDescription);
+      }
+      if (canonicalPath) {
+        upsertCanonical(defaults.canonical);
+        upsertMeta("property", "og:url", defaults.ogUrl);
+      }
+      if (robots) upsertMeta("name", "robots", defaults.robots);
     };
   }, [title, description, canonicalPath, robots]);
 }

--- a/src/pages/DailyPicks.tsx
+++ b/src/pages/DailyPicks.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState, useRef } from "react";
 import DeskNav from "@/components/DeskNav";
 import { useDocumentMeta } from "@/lib/useDocumentMeta";
+import { routeMeta } from "@/lib/routeSeo";
 import { Link } from "react-router-dom";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -641,12 +642,7 @@ function PickCard({
 }
 
 export default function DailyPicks() {
-  useDocumentMeta({
-    title: "Daily Picks — AI Advantage Sports",
-    description:
-      "The full execution board: every qualified play with model probability, execution-adjusted edge, recommended stake, and entry window.",
-    canonicalPath: "/daily-picks",
-  });
+  useDocumentMeta(routeMeta("/daily-picks"));
 
   const [access, setAccess] = useState(getAccessState());
   const [cryptoAccount, setCryptoAccount] = useState(getCurrentCryptoAccount());

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense, useEffect, useMemo, useState } from "react";
 import { useDocumentMeta } from "@/lib/useDocumentMeta";
+import { routeMeta } from "@/lib/routeSeo";
 import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -285,12 +286,7 @@ function formatMarketAudit(game: LiveMarketGame) {
 }
 
 function Index() {
-  useDocumentMeta({
-    title: "AI Advantage Sports — Live Lines, Model Edge, Kelly Sizing",
-    description:
-      "Execution-first sports betting intelligence: live lines, model probabilities, execution-adjusted edge, and quarter-Kelly stake guidance for NBA, NFL, MLB, and the World Cup.",
-    canonicalPath: "/",
-  });
+  useDocumentMeta(routeMeta("/"));
 
   const [gameInput, setGameInput] = useState("");
   const [bettingAdvice, setBettingAdvice] = useState("");

--- a/src/pages/Leaderboard.tsx
+++ b/src/pages/Leaderboard.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import DeskNav from "@/components/DeskNav";
 import { useDocumentMeta } from "@/lib/useDocumentMeta";
+import { routeMeta } from "@/lib/routeSeo";
 import { Link } from "react-router-dom";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -130,12 +131,7 @@ function HistoryTable({ rows }: { rows: HistoricalExecutionLedgerEntry[] }) {
 }
 
 export default function Leaderboard() {
-  useDocumentMeta({
-    title: "Proof Ledger — AI Advantage Sports",
-    description:
-      "The public settled record: graded picks, closing-line value, and calibration history for every recommendation the desk has made.",
-    canonicalPath: "/leaderboard",
-  });
+  useDocumentMeta(routeMeta("/leaderboard"));
 
   const [access, setAccess] = useState(getAccessState());
   const [games, setGames] = useState<LiveMarketGame[]>([]);

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, type FormEvent } from "react";
 import { useDocumentMeta } from "@/lib/useDocumentMeta";
+import { routeMeta } from "@/lib/routeSeo";
 import { Link, useNavigate } from "react-router-dom";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -11,11 +12,7 @@ import { KeyRound, LockOpen, UserCircle2 } from "lucide-react";
 import BrandedHeader from "@/components/BrandedHeader";
 
 export default function Login() {
-  useDocumentMeta({
-    title: "Log In — AI Advantage Sports",
-    description: "Log in to AI Advantage Sports to reach your execution desk and proof ledger.",
-    canonicalPath: "/login",
-  });
+  useDocumentMeta(routeMeta("/login"));
 
   const navigate = useNavigate();
   const { toast } = useToast();

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -2,6 +2,7 @@ import { Link, useLocation } from "react-router-dom";
 import { ArrowLeft, Compass } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useDocumentMeta } from "@/lib/useDocumentMeta";
+import { notFoundMeta } from "@/lib/routeSeo";
 
 const SUGGESTIONS = [
   { to: "/", label: "Live desk", detail: "Current slate, model edge, and Kelly sizing" },
@@ -19,10 +20,7 @@ export default function NotFound() {
 
   // The SPA fallback serves this at a 200, so the status code can't say "gone".
   // The robots tag is what actually keeps mistyped URLs out of the index.
-  useDocumentMeta({
-    title: "Page not found — AI Advantage Sports",
-    robots: "noindex,follow",
-  });
+  useDocumentMeta(notFoundMeta);
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-[#05070d] px-5 py-16 text-slate-100">

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useDocumentMeta } from "@/lib/useDocumentMeta";
+import { routeMeta } from "@/lib/routeSeo";
 import { Link, useNavigate } from "react-router-dom";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -57,12 +58,7 @@ function shorten(value: string, start = 8, end = 6): string {
 }
 
 export default function Profile() {
-  useDocumentMeta({
-    title: "Your Account — AI Advantage Sports",
-    description: "Manage your AI Advantage Sports subscription, bankroll defaults, and session.",
-    canonicalPath: "/profile",
-    robots: "noindex,follow",
-  });
+  useDocumentMeta(routeMeta("/profile"));
 
   const navigate = useNavigate();
   const [access, setAccess] = useState<AccessState>(getAccessState());

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, type FormEvent } from "react";
 import { useDocumentMeta } from "@/lib/useDocumentMeta";
+import { routeMeta } from "@/lib/routeSeo";
 import { Link, useNavigate } from "react-router-dom";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -11,11 +12,7 @@ import { Check, Sparkles, UserPlus } from "lucide-react";
 import BrandedHeader from "@/components/BrandedHeader";
 
 export default function Signup() {
-  useDocumentMeta({
-    title: "Create Account — AI Advantage Sports",
-    description: "Create an AI Advantage Sports account to track picks, sizing, and settled proof.",
-    canonicalPath: "/signup",
-  });
+  useDocumentMeta(routeMeta("/signup"));
 
   const navigate = useNavigate();
   const { toast } = useToast();


### PR DESCRIPTION
## Problem

The app is a client-rendered SPA behind a Netlify `/* → /index.html 200` fallback, so **every route was served the homepage's `<head>`**. Concretely:

- `/daily-picks`, `/leaderboard`, `/login`, `/signup` each shipped `<link rel="canonical" href="https://aiadvantagesports.com/">` — telling crawlers they were duplicates of the homepage — **while `sitemap.xml` submitted those same URLs for indexing.** The sitemap and the pages were contradicting each other, and the canonical wins.
- Non-JS social scrapers (Slack, iMessage, Facebook, LinkedIn) read the homepage OG card on every shared subroute.
- `sitemap.xml` had a hand-edited `lastmod` constant that silently went stale.
- The homepage's static `<title>` and its client-set `<title>` had drifted apart.

`useDocumentMeta` fixed the title/canonical client-side, but only for crawlers that execute JS — and the code already flagged per-route prerendered heads as the natural follow-up.

## What changed

- **`src/data/seo.json` — one source of truth.** Per-route title, description, robots, and sitemap weighting. The pages (`useDocumentMeta`), the build-time prerender, and the sitemap all read from it, so page copy, the crawlable static head, and the sitemap can no longer drift.
- **`scripts/prerender.mjs` — per-route static heads.** Emits `dist/<route>/index.html` for each indexable subroute with a correct head (title, description, **self-referential canonical**, Open Graph / Twitter, and `WebPage` + `BreadcrumbList` structured data replacing the homepage's `WebApplication`) plus a small, honest crawler-facing body (`<h1>` + lead line + internal links). Netlify serves these directory-index files at the clean URL ahead of the SPA fallback; **if the step is ever skipped, the fallback still serves the app** (no 404 risk — no routing rules were changed).
- **`scripts/prerender.mjs` — generated sitemap.** `dist/sitemap.xml` is regenerated from `seo.json` with a build-date `lastmod` on every deploy.
- **`src/lib/useDocumentMeta.ts` — OG/Twitter per route.** Now also drives `og:`/`twitter:` title/description/url (derived from the same title/description) so in-app navigation and any non-prerendered route stay accurate.
- **`index.html`** — unify the homepage title with the app (they had diverged) and add `Organization` structured data (real Substack + LinkedIn profiles).
- **`scripts/lib/seo.mjs` (+ `seo.test.mjs`)** — pure, tested helpers for the head rewrites, per-page structured data, and sitemap generation.

The seven page refactors are behavior-preserving for title/description/canonical/robots — the values in `seo.json` match the previous inline copy exactly; they just come from one place now and gain the derived OG tags.

## Why the Netlify approach is safe

Per-route output is written as `dist/<route>/index.html` (directory-index). Netlify serves existing static files ahead of a non-forced `200` rewrite, so these win over the SPA fallback at the clean URL, and the canonical resolves any trailing-slash ambiguity. Nothing in `netlify.toml` or `_redirects` was touched, so the worst case of a skipped prerender is exactly today's behavior.

## Verification

All four CI checks pass locally:

- `npx tsc -b --force` — clean
- `npm run lint` — clean
- `npm test` — 135 passed (19 new in `scripts/lib/seo.test.mjs`)
- `npm run build` — writes `dist/{daily-picks,leaderboard,login,signup}/index.html` and a fresh `dist/sitemap.xml`

Inspected the built output: each subroute carries its own canonical/OG/`WebPage` head, references **absolute** `/assets/*` CSS+JS (so the nested file boots the full SPA), and no longer leaks the homepage `WebApplication` markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TNSu17PnzaBGF8gnGsyVvc)_