### PR TITLE
Declare color-scheme: dark so browser-owned UI matches the app

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -33,6 +33,12 @@
 
   html {
     scroll-behavior: smooth;
+    /* This is a dark-only UI, but nothing declared that, so browsers treated it
+       as a light page and styled everything they own to match: scrollbars,
+       native form controls, and — most visibly — the autofill wash over the
+       login and signup inputs. Declaring the scheme is what makes those pick
+       the dark treatment. */
+    color-scheme: dark;
   }
 
   body {


### PR DESCRIPTION
Small one. The app is dark-only, but nothing declared that, so browsers treated it as a light page and styled everything they own to match: scrollbars, native form controls, and the autofill wash over the login and signup inputs.

One declaration on `html`. No component changes.

```css
html {
  scroll-behavior: smooth;
  color-scheme: dark;
}
```

## Verification

- `npx tsc -b --force` — clean (CI's exact command)
- `npm run lint` — 0 errors
- `npm test` — 135 passed
- `npm run build` — succeeds
- Keyboard pass over `/`, `/daily-picks`, `/leaderboard`, `/login`, `/signup`: a focus indicator on every tab stop, no horizontal overflow, no console errors

## What I looked at and did not change

This started as a broader hunt. Recording the negatives so nobody re-derives them:

- **Performance** is fine and needs no work: FCP 224ms, LCP 224ms, CLS 0.0000, 172KB transferred, 1 script (mobile, production build).
- **Reduced motion** is fully handled — zero infinite animations survive `prefers-reduced-motion: reduce` on any page. `LiveOddsTicker` already disables its marquee correctly.
- **Text contrast** passes WCAG AA across `/`, `/daily-picks`, `/leaderboard`, `/login`. The one apparent failure (an "Unlock event pass" CTA at 1.05:1) is a false positive in my checker — the button has a `bg-gradient-to-r` yellow/orange `background-image`, which a `backgroundColor`-based walker can't see. Black on that gradient is high contrast; screenshot confirmed.

## One thing I could not establish

I also tried to fix the default focus-ring colour, on the theory that it resolved near-black against the near-black background. My measurements were **not reproducible** — the same element reported `rgb(16,16,16)` in one run and `rgb(239,245,244)` in another — so I can't substantiate a claim either way, and I removed the custom `:focus-visible` outline rule I had drafted rather than ship something I couldn't show working. Every tab stop does have *an* indicator; whether the UA ring has adequate contrast on this background is worth a look with real assistive-tech testing rather than my scripted probe.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdPKFZwNqyNihKVYGXB63L)_