### PR TITLE
fix(deps): bump @netlify/blobs to ^11.0.1 to drop vulnerable image-size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ai-advantage",
       "version": "0.0.0",
       "dependencies": {
-        "@netlify/blobs": "^10.7.11",
+        "@netlify/blobs": "^11.0.1",
         "@radix-ui/react-dialog": "^1.1.23",
         "@radix-ui/react-label": "^2.1.15",
         "@radix-ui/react-slider": "^1.4.7",
@@ -446,9 +446,9 @@
       }
     },
     "node_modules/@fastify/busboy": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.0.tgz",
-      "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.2.tgz",
+      "integrity": "sha512-yXSS27qPExaXeuLvMRMXOLtpipzfQYNjG3FkunDWKGfMYjKuhFXko9CVzqxm8jcF+lmtS9Fd89QNdh9XDjnbNg==",
       "license": "MIT"
     },
     "node_modules/@floating-ui/core": {
@@ -606,42 +606,39 @@
       }
     },
     "node_modules/@netlify/blobs": {
-      "version": "10.7.11",
-      "resolved": "https://registry.npmjs.org/@netlify/blobs/-/blobs-10.7.11.tgz",
-      "integrity": "sha512-jnP4KAWP10GEynBk1GOaHBBnL1pF03sL3sQM5h9q+zJdedvCMV8zS3iTHzhm3B1zG4h8pDqDgOnUP8GqRDAXnA==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@netlify/blobs/-/blobs-11.0.1.tgz",
+      "integrity": "sha512-ohmcoesUSdIU6FSZhq4EwDu6sYBWrfywRQdyUOYo/a7Rnc1VLot8w2d0npQzr/YuRgJFqV50OZ0Eg3GOCnRUcQ==",
       "license": "MIT",
       "dependencies": {
-        "@netlify/dev-utils": "4.4.7",
-        "@netlify/otel": "^6.0.5",
-        "@netlify/runtime-utils": "2.3.0"
+        "@netlify/dev-utils": "6.0.1",
+        "@netlify/otel": "^7.0.1",
+        "@netlify/runtime-utils": "3.0.0"
       },
       "engines": {
-        "node": "^14.16.0 || >=16.0.0"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@netlify/dev-utils": {
-      "version": "4.4.7",
-      "resolved": "https://registry.npmjs.org/@netlify/dev-utils/-/dev-utils-4.4.7.tgz",
-      "integrity": "sha512-etfUY5SyraYG+i4msfVnWuFEkia6XLxeoe8Hh5uGO6QJ4OAQT4EmesXjulsI0/7EozMxdiANGnf2AAshn+2jpQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@netlify/dev-utils/-/dev-utils-6.0.1.tgz",
+      "integrity": "sha512-q5g70dO3q/M/XTBQz7uIECJxVlJoS8UBlzpjf22DV6q61UzXa8EONTPXPmvisrFcUi1I3AUKplPcHGQYZZj+Vw==",
       "license": "MIT",
       "dependencies": {
         "@whatwg-node/server": "^0.11.0",
         "ansis": "^4.1.0",
         "atomically": "^2.0.3",
-        "chokidar": "^4.0.1",
+        "chokidar": "^5.0.0",
         "decache": "^4.6.2",
         "dettle": "^1.0.5",
         "dot-prop": "9.0.0",
         "empathic": "^2.0.0",
         "env-paths": "^3.0.0",
-        "image-size": "^2.0.2",
-        "js-image-generator": "^1.0.4",
         "parse-gitignore": "^2.0.0",
-        "semver": "^7.7.2",
-        "tmp-promise": "^3.0.3"
+        "semver": "^7.7.2"
       },
       "engines": {
-        "node": "^18.14.0 || >=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@netlify/dev-utils/node_modules/semver": {
@@ -657,9 +654,9 @@
       }
     },
     "node_modules/@netlify/otel": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/@netlify/otel/-/otel-6.0.5.tgz",
-      "integrity": "sha512-FUnQsG+xp5gljmHZgrBgGLYKmKYQlGvrao6gtKenJSPCYTMzsYB9PbFfjIoEvwS+o8DxuWDrHlRDDGU3o9ObhQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@netlify/otel/-/otel-7.0.1.tgz",
+      "integrity": "sha512-9GVV5b/Fb1nfXbooy46YcR6YrzTV0wjTC70y4Em6xgcckpvgi5F9hWQssl7UGIMp0abx9WxTAz2LPITTCnarKQ==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "1.9.1",
@@ -669,16 +666,16 @@
         "@opentelemetry/sdk-trace-node": "2.9.0"
       },
       "engines": {
-        "node": "^18.14.0 || >=20.6.1"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@netlify/runtime-utils": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@netlify/runtime-utils/-/runtime-utils-2.3.0.tgz",
-      "integrity": "sha512-cW8weDvsKV7zfia2m5EcBy6KILGoPD+eYZ3qWNGnIo05DGF28goPES0xKSDkNYgAF/2rRSIhie2qcBhbGVgSRg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@netlify/runtime-utils/-/runtime-utils-3.0.0.tgz",
+      "integrity": "sha512-OHo40+V3QZkR+UrDjqhN+LekrAby/dSSJxsvyYs9i88E/mSl3goB/ysoL+VYROm190egxmQyRYlHK7vL4GeHBQ==",
       "license": "MIT",
       "engines": {
-        "node": "^18.14.0 || >=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@opentelemetry/api": {
@@ -3272,24 +3269,24 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "license": "MIT",
       "dependencies": {
-        "readdirp": "^4.0.1"
+        "readdirp": "^5.0.0"
       },
       "engines": {
-        "node": ">= 14.16.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/cjs-module-lexer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
-      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.1.tgz",
+      "integrity": "sha512-Ca8swihM+/4yKecYHY52kgJd300hi2lADU/a1RxNTRe+RJ9jvqQlESpbz9DnG9mowez8qwXHB8qYdIUw9e+F5Q==",
       "license": "MIT"
     },
     "node_modules/class-variance-authority": {
@@ -4037,18 +4034,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/image-size": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
-      "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
-      "license": "MIT",
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=16.x"
-      }
-    },
     "node_modules/immer": {
       "version": "11.1.9",
       "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.9.tgz",
@@ -4130,21 +4115,6 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "node_modules/jpeg-js": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
-      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/js-image-generator": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/js-image-generator/-/js-image-generator-1.0.4.tgz",
-      "integrity": "sha512-ckb7kyVojGAnArouVR+5lBIuwU1fcrn7E/YYSd0FK7oIngAkMmRvHASLro9Zt5SQdWToaI66NybG+OGxPw/HlQ==",
-      "license": "ISC",
-      "dependencies": {
-        "jpeg-js": "^0.4.2"
       }
     },
     "node_modules/js-tokens": {
@@ -4943,12 +4913,12 @@
       }
     },
     "node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
       "license": "MIT",
       "engines": {
-        "node": ">= 14.18.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "type": "individual",
@@ -5266,24 +5236,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/tmp": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
-      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/tmp-promise": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
-      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
-      "license": "MIT",
-      "dependencies": {
-        "tmp": "^0.2.0"
       }
     },
     "node_modules/ts-api-utils": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "hermes:publish": "node scripts/hermes-substack-publish.mjs"
   },
   "dependencies": {
-    "@netlify/blobs": "^10.7.11",
+    "@netlify/blobs": "^11.0.1",
     "@radix-ui/react-dialog": "^1.1.23",
     "@radix-ui/react-label": "^2.1.15",
     "@radix-ui/react-slider": "^1.4.7",


### PR DESCRIPTION
## What

Resolves **both open high-severity Dependabot alerts** on this repo.

## Why a direct bump was needed

The alerts are two DoS advisories in `image-size <= 2.0.2` (ICNS infinite loop; JXL/HEIF infinite loop). Critically, **neither has a patched version published** — `first_patched_version` is `null`, so the transitive dep cannot be fixed by bumping `image-size` itself.

It reached the tree only via:

```
@netlify/blobs@10.7.11 -> @netlify/dev-utils@4.4.7 -> image-size@2.0.2
```

`@netlify/blobs@11` drops that path entirely. After the bump `npm ls image-size --all` reports an empty tree, so the alerts are **resolved at the source** rather than suppressed with an override or ignore rule.

## Why the major bump is safe

`@netlify/blobs` is a **production** dependency used across 7 payment / auth / entitlement modules, so this was checked rather than assumed:

- v11 still exports every API this repo imports — `getStore`, `connectLambda`, `setEnvironmentContext`
- `tsc` type-checks all 7 call sites against **v11's own** type definitions and passes

## Verification

| Check | Result |
|---|---|
| `tsc -b --force` | ✅ rc=0 |
| `npm run build` | ✅ rc=0 |
| `npm run lint` | ✅ rc=0 |
| `vitest run` | ✅ 19 files, **141 tests** passed |

## Scope

`package.json` + lockfile only. One dependency line changed.