### PR TITLE
test(smoke): retry transient connect failures to prod

### DIFF
--- a/tests/smoke/billing-auth.smoke.test.ts
+++ b/tests/smoke/billing-auth.smoke.test.ts
@@ -4,13 +4,39 @@
  */
 import { describe, expect, it } from "vitest";
 
+/**
+ * Retry a fetch against production a few times before giving up. The scheduled
+ * smoke runs hit the live site from GitHub runners, and 18 of the last 30 runs
+ * failed on a single connect-timeout to /api/billing-status while the site was
+ * healthy — transient network blips between runner and host, not outages.
+ */
+async function fetchWithRetry(
+  url: string,
+  init: RequestInit = {},
+  attempts = 3,
+): Promise<Response> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await fetch(url, {
+        ...init,
+        signal: AbortSignal.timeout(15000),
+      });
+    } catch (err) {
+      lastError = err;
+      if (attempt < attempts) {
+        await new Promise((r) => setTimeout(r, 2000 * attempt));
+      }
+    }
+  }
+  throw lastError;
+}
+
 const BASE_URL = (process.env.SMOKE_BASE_URL || "https://aiadvantagesports.com").replace(/\/$/, "");
 
 describe("production billing + auth smoke", () => {
   it("exposes billing-status with a coherent checkout readiness shape", async () => {
-    const response = await fetch(`${BASE_URL}/api/billing-status`, {
-      signal: AbortSignal.timeout(15000),
-    });
+    const response = await fetchWithRetry(`${BASE_URL}/api/billing-status`);
     expect(response.status).toBe(200);
     const status = (await response.json()) as Record<string, unknown>;
 


### PR DESCRIPTION
## Summary
- Adds `fetchWithRetry` to the production billing smoke: retries connect failures up to 3x with backoff before failing.

## Why
18 of the last 30 scheduled smoke runs failed on a **single connect-timeout** to `/api/billing-status` while the site was healthy (verified 200 in ~0.2s). These are transient runner-to-host network blips, not outages — the test had zero tolerance for them and each one paged the repo red.

## Test plan
- [x] No behavior change when prod is reachable (first attempt succeeds)
- [x] Fails loudly after 3 genuine attempts if prod is truly down
